### PR TITLE
Implement data model and canonicalization infrastructure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,6 +96,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
+name = "bitflags"
+version = "2.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
+
+[[package]]
 name = "bstr"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -289,12 +310,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.0",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
 name = "float-cmp"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "getrandom"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasi",
 ]
 
 [[package]]
@@ -393,6 +448,7 @@ dependencies = [
  "anyhow",
  "assert_cmd",
  "predicates",
+ "proptest",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -418,10 +474,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "libc"
 version = "0.2.176"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58f929b4d672ea937a23a1ab494143d968337a5f47e56d0815df1e0890ddf174"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "log"
@@ -497,6 +565,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "predicates"
 version = "3.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -536,12 +613,82 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bb0be07becd10686a0bb407298fb425360a5c44a663774406340c59a22de4ce"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags",
+ "lazy_static",
+ "num-traits",
+ "rand",
+ "rand_chacha",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
 name = "quote"
 version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core",
 ]
 
 [[package]]
@@ -594,10 +741,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
 
 [[package]]
+name = "rustix"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.0",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "ryu"
@@ -688,6 +860,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.0",
+]
+
+[[package]]
 name = "termtree"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -724,6 +909,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -758,6 +949,24 @@ checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
 dependencies = [
  "same-file",
  "winapi-util",
+]
+
+[[package]]
+name = "wasi"
+version = "0.14.7+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "883478de20367e224c0090af9cf5f9fa85bed63a95c1abf3afc5c083ebc06e8c"
+dependencies = [
+ "wasip2",
+]
+
+[[package]]
+name = "wasip2"
+version = "1.0.1+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+dependencies = [
+ "wit-bindgen",
 ]
 
 [[package]]
@@ -1005,3 +1214,29 @@ name = "windows_x86_64_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
+
+[[package]]
+name = "wit-bindgen"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+
+[[package]]
+name = "zerocopy"
+version = "0.8.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0894878a5fa3edfd6da3f88c4805f4c8558e2b996227a3d864f47fe11e38282c"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ tracing-subscriber = { version = "0.3.19", features = [
 ] }
 assert_cmd = "2.0"
 predicates = "3.1"
+proptest = "1.5"
 
 [workspace.lints.clippy]
 all = "deny"

--- a/crates/jd-core/Cargo.toml
+++ b/crates/jd-core/Cargo.toml
@@ -17,3 +17,4 @@ serde_yaml = { workspace = true }
 [dev-dependencies]
 assert_cmd = { workspace = true }
 predicates = { workspace = true }
+proptest = { workspace = true }

--- a/crates/jd-core/src/error.rs
+++ b/crates/jd-core/src/error.rs
@@ -1,0 +1,51 @@
+use thiserror::Error;
+
+/// Errors that can occur while canonicalizing external data into [`Node`].
+#[derive(Debug, Error)]
+pub enum CanonicalizeError {
+    /// The provided JSON input was invalid.
+    #[error("invalid JSON: {0}")]
+    Json(#[from] serde_json::Error),
+    /// The provided YAML input was invalid.
+    #[error("invalid YAML: {0}")]
+    Yaml(#[from] serde_yaml::Error),
+    /// Encountered a number that cannot be represented as an IEEE-754 f64.
+    #[error("number {value} cannot be represented as f64")]
+    NumberOutOfRange {
+        /// The textual representation of the offending number.
+        value: String,
+    },
+    /// YAML maps may only contain string keys.
+    #[error("unsupported YAML key type: {found}")]
+    NonStringYamlKey {
+        /// A description of the key that triggered the error.
+        found: String,
+    },
+    /// YAML tags are not supported by the Go implementation and therefore
+    /// rejected by the Rust port as well.
+    #[error("unsupported YAML tag: {tag}")]
+    UnsupportedYamlTag {
+        /// The tag identifier encountered in the document.
+        tag: String,
+    },
+    /// Attempted to construct a [`Number`] that is not finite.
+    #[error("non-finite number encountered: {value}")]
+    NotFinite {
+        /// The offending numeric value.
+        value: f64,
+    },
+}
+
+/// Errors emitted when constructing [`DiffOptions`].
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum OptionsError {
+    /// Precision tolerance is incompatible with set or multiset semantics.
+    #[error("precision tolerance cannot be combined with set or multiset array modes")]
+    PrecisionIncompatible,
+    /// Set keys require arrays to operate in set mode.
+    #[error("set keys require array mode to be set")]
+    SetKeysRequireSetMode,
+    /// Set keys must be non-empty strings.
+    #[error("set keys must be non-empty strings")]
+    EmptySetKey,
+}

--- a/crates/jd-core/src/hash.rs
+++ b/crates/jd-core/src/hash.rs
@@ -1,0 +1,27 @@
+/// Type alias representing the 64-bit hash code used throughout the diff engine.
+pub type HashCode = [u8; 8];
+
+/// Compute the FNV-1a hash of the provided bytes.
+#[must_use]
+pub fn hash_bytes(input: &[u8]) -> HashCode {
+    const OFFSET_BASIS: u64 = 0xcbf29ce484222325;
+    const PRIME: u64 = 0x100000001b3;
+
+    let mut hash = OFFSET_BASIS;
+    for byte in input {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(PRIME);
+    }
+    hash.to_le_bytes()
+}
+
+/// Combine a collection of hash codes into a single aggregate hash.
+#[must_use]
+pub fn combine(mut codes: Vec<HashCode>) -> HashCode {
+    codes.sort_unstable();
+    let mut bytes = Vec::with_capacity(codes.len() * 8);
+    for code in codes {
+        bytes.extend_from_slice(&code);
+    }
+    hash_bytes(&bytes)
+}

--- a/crates/jd-core/src/lib.rs
+++ b/crates/jd-core/src/lib.rs
@@ -1,25 +1,37 @@
-//! Core library for the Rust port of the `jd` JSON diff tool.
+//! Core primitives for the Rust port of the `jd` JSON diff tool.
 //!
-//! This crate will eventually expose the data model, canonicalization
-//! pipeline, diff engine, and patch application APIs that mirror the Go
-//! implementation. During the workspace scaffolding milestone it only
-//! provides version metadata to enable smoke tests and doctest coverage.
-//!
-//! # Examples
+//! The crate currently exposes the canonical data model used by the diff
+//! engine together with helpers for parsing JSON/YAML inputs into the
+//! canonical representation. Future milestones will extend this module with
+//! diffing, patching, rendering, and canonicalization pipelines that mirror
+//! the Go implementation.
 //!
 //! ```
-//! use jd_core::version;
+//! use jd_core::{Node, DiffOptions};
 //!
-//! assert!(version().starts_with('0'));
+//! // Parse two JSON fragments and compare them structurally.
+//! let lhs = Node::from_json_str("{\"name\": \"jd\", \"version\": 2}")?;
+//! let rhs = Node::from_json_str("{\"version\": 2, \"name\": \"jd\"}")?;
+//!
+//! let opts = DiffOptions::default();
+//! assert!(lhs.eq_with_options(&rhs, &opts));
+//! # Ok::<(), jd_core::CanonicalizeError>(())
 //! ```
 #![forbid(unsafe_code)]
 #![warn(missing_docs)]
 
+mod error;
+mod hash;
+mod node;
+mod number;
+mod options;
+
+pub use error::{CanonicalizeError, OptionsError};
+pub use node::Node;
+pub use number::Number;
+pub use options::{ArrayMode, DiffOptions};
+
 /// Returns the semantic version of the `jd-core` crate.
-///
-/// The value is sourced from the crate metadata at compile time. This
-/// helper keeps doctests alive while the rest of the surface is still
-/// under construction.
 ///
 /// ```
 /// assert!(!jd_core::version().is_empty());

--- a/crates/jd-core/src/node.rs
+++ b/crates/jd-core/src/node.rs
@@ -1,0 +1,411 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value as JsonValue;
+use serde_yaml::Value as YamlValue;
+
+use crate::{
+    hash::{combine, hash_bytes, HashCode},
+    ArrayMode, CanonicalizeError, DiffOptions, Number,
+};
+
+const VOID_HASH: HashCode = [0xF3, 0x97, 0x6B, 0x21, 0x91, 0x26, 0x8D, 0x96];
+const NULL_HASH: HashCode = [0xFE, 0x73, 0xAB, 0xCC, 0xE6, 0x32, 0xE0, 0x88];
+const BOOL_TRUE_HASH: HashCode = [0x24, 0x6B, 0xE3, 0xE4, 0xAF, 0x59, 0xDC, 0x1C];
+const BOOL_FALSE_HASH: HashCode = [0xC6, 0x38, 0x77, 0xD1, 0x0A, 0x7E, 0x1F, 0xBF];
+const LIST_SEED: [u8; 8] = [0xF5, 0x18, 0x0A, 0x71, 0xA4, 0xC4, 0x03, 0xF3];
+const OBJECT_SEED: [u8; 8] = [0x00, 0x5D, 0x39, 0xA4, 0x18, 0x10, 0xEA, 0xD5];
+
+/// Represents the canonical JSON data model used by the diff engine.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type", content = "value")]
+pub enum Node {
+    /// Sentinel representing the absence of a value.
+    Void,
+    /// JSON `null`.
+    Null,
+    /// JSON boolean.
+    Bool(bool),
+    /// JSON number represented as IEEE-754 double precision.
+    Number(Number),
+    /// JSON string.
+    String(String),
+    /// JSON array.
+    Array(Vec<Node>),
+    /// JSON object with deterministic key ordering.
+    Object(BTreeMap<String, Node>),
+}
+
+impl Node {
+    /// Parses a JSON string into the canonical node representation.
+    ///
+    /// ```
+    /// # use jd_core::Node;
+    /// let node = Node::from_json_str("{\"hello\":\"world\"}")?;
+    /// assert!(matches!(node, Node::Object(_)));
+    /// # Ok::<(), jd_core::CanonicalizeError>(())
+    /// ```
+    pub fn from_json_str(input: &str) -> Result<Self, CanonicalizeError> {
+        if input.trim().is_empty() {
+            return Ok(Self::Void);
+        }
+        let value: JsonValue = serde_json::from_str(input)?;
+        Self::from_json_value(value)
+    }
+
+    /// Parses a YAML string into the canonical node representation.
+    ///
+    /// ```
+    /// # use jd_core::Node;
+    /// let node = Node::from_yaml_str("---\nanswer: 42\n")?;
+    /// assert!(matches!(node, Node::Object(_)));
+    /// # Ok::<(), jd_core::CanonicalizeError>(())
+    /// ```
+    pub fn from_yaml_str(input: &str) -> Result<Self, CanonicalizeError> {
+        if input.trim().is_empty() {
+            return Ok(Self::Void);
+        }
+        let value: YamlValue = serde_yaml::from_str(input)?;
+        Self::from_yaml_value(value)
+    }
+
+    /// Converts a serde JSON value into a [`Node`].
+    pub fn from_json_value(value: JsonValue) -> Result<Self, CanonicalizeError> {
+        match value {
+            JsonValue::Null => Ok(Self::Null),
+            JsonValue::Bool(v) => Ok(Self::Bool(v)),
+            JsonValue::Number(num) => {
+                let text = num.to_string();
+                let Some(as_f64) = num.as_f64() else {
+                    return Err(CanonicalizeError::NumberOutOfRange { value: text });
+                };
+                Ok(Self::Number(Number::new(as_f64)?))
+            }
+            JsonValue::String(s) => Ok(Self::String(s)),
+            JsonValue::Array(values) => {
+                let mut items = Vec::with_capacity(values.len());
+                for value in values {
+                    items.push(Self::from_json_value(value)?);
+                }
+                Ok(Self::Array(items))
+            }
+            JsonValue::Object(map) => {
+                let mut object = BTreeMap::new();
+                for (key, value) in map {
+                    object.insert(key, Self::from_json_value(value)?);
+                }
+                Ok(Self::Object(object))
+            }
+        }
+    }
+
+    fn from_yaml_value(value: YamlValue) -> Result<Self, CanonicalizeError> {
+        match value {
+            YamlValue::Null => Ok(Self::Null),
+            YamlValue::Bool(v) => Ok(Self::Bool(v)),
+            YamlValue::Number(num) => {
+                if let Some(f) = num.as_f64() {
+                    return Ok(Self::Number(Number::new(f)?));
+                }
+                if let Some(i) = num.as_i64() {
+                    return Ok(Self::Number(Number::new(i as f64)?));
+                }
+                if let Some(u) = num.as_u64() {
+                    return Ok(Self::Number(Number::new(u as f64)?));
+                }
+                Err(CanonicalizeError::NumberOutOfRange { value: num.to_string() })
+            }
+            YamlValue::String(s) => Ok(Self::String(s)),
+            YamlValue::Sequence(seq) => {
+                let mut items = Vec::with_capacity(seq.len());
+                for value in seq {
+                    items.push(Self::from_yaml_value(value)?);
+                }
+                Ok(Self::Array(items))
+            }
+            YamlValue::Mapping(map) => {
+                let mut object = BTreeMap::new();
+                for (key, value) in map {
+                    let key = match key {
+                        YamlValue::String(s) => s,
+                        other => {
+                            return Err(CanonicalizeError::NonStringYamlKey {
+                                found: format!("{other:?}"),
+                            });
+                        }
+                    };
+                    object.insert(key, Self::from_yaml_value(value)?);
+                }
+                Ok(Self::Object(object))
+            }
+            YamlValue::Tagged(tagged) => {
+                Err(CanonicalizeError::UnsupportedYamlTag { tag: tagged.tag.to_string() })
+            }
+        }
+    }
+
+    /// Converts the node into a serde JSON value when representable.
+    ///
+    /// Returns `None` when the node contains the `Void` sentinel (either at the
+    /// root or nested within arrays/objects) because `serde_json::Value` cannot
+    /// represent the absence of a value.
+    #[must_use]
+    pub fn to_json_value(&self) -> Option<JsonValue> {
+        match self {
+            Self::Void => None,
+            Self::Null => Some(JsonValue::Null),
+            Self::Bool(v) => Some(JsonValue::Bool(*v)),
+            Self::Number(n) => serde_json::Number::from_f64(n.get()).map(JsonValue::Number),
+            Self::String(s) => Some(JsonValue::String(s.clone())),
+            Self::Array(values) => {
+                let mut result = Vec::with_capacity(values.len());
+                for value in values {
+                    result.push(value.to_json_value()?);
+                }
+                Some(JsonValue::Array(result))
+            }
+            Self::Object(map) => {
+                let mut object = serde_json::Map::new();
+                for (key, value) in map {
+                    object.insert(key.clone(), value.to_json_value()?);
+                }
+                Some(JsonValue::Object(object))
+            }
+        }
+    }
+
+    /// Structural equality that respects [`DiffOptions`].
+    ///
+    /// ```
+    /// # use jd_core::{ArrayMode, DiffOptions, Node};
+    /// let lhs = Node::from_json_str("[1,2]")?;
+    /// let rhs = Node::from_json_str("[2,1]")?;
+    /// let opts = DiffOptions::default().with_array_mode(ArrayMode::Set).expect("set mode");
+    /// assert!(lhs.eq_with_options(&rhs, &opts));
+    /// # Ok::<(), jd_core::CanonicalizeError>(())
+    /// ```
+    #[must_use]
+    pub fn eq_with_options(&self, other: &Self, options: &DiffOptions) -> bool {
+        match (self, other) {
+            (Self::Void, Self::Void) => true,
+            (Self::Null, Self::Null) => true,
+            (Self::Bool(a), Self::Bool(b)) => a == b,
+            (Self::Number(a), Self::Number(b)) => a.equals_with_precision(*b, options.precision()),
+            (Self::String(a), Self::String(b)) => a == b,
+            (Self::Array(a), Self::Array(b)) => match options.array_mode() {
+                ArrayMode::List => list_equals(a, b, options),
+                ArrayMode::Set => set_equals(a, b, options),
+                ArrayMode::MultiSet => multiset_equals(a, b, options),
+            },
+            (Self::Object(a), Self::Object(b)) => {
+                if a.len() != b.len() {
+                    return false;
+                }
+                for (key, value_a) in a {
+                    let Some(value_b) = b.get(key) else {
+                        return false;
+                    };
+                    if !value_a.eq_with_options(value_b, options) {
+                        return false;
+                    }
+                }
+                true
+            }
+            _ => false,
+        }
+    }
+
+    /// Computes the Go-compatible hash code for this node.
+    #[must_use]
+    pub fn hash_code(&self, options: &DiffOptions) -> HashCode {
+        match self {
+            Self::Void => VOID_HASH,
+            Self::Null => NULL_HASH,
+            Self::Bool(true) => BOOL_TRUE_HASH,
+            Self::Bool(false) => BOOL_FALSE_HASH,
+            Self::Number(n) => n.hash_code(),
+            Self::String(s) => hash_bytes(s.as_bytes()),
+            Self::Array(values) => match options.array_mode() {
+                ArrayMode::List => hash_list(values, options),
+                ArrayMode::Set => hash_set(values, options),
+                ArrayMode::MultiSet => hash_multiset(values, options),
+            },
+            Self::Object(map) => hash_object(map, options),
+        }
+    }
+}
+
+impl TryFrom<JsonValue> for Node {
+    type Error = CanonicalizeError;
+
+    fn try_from(value: JsonValue) -> Result<Self, Self::Error> {
+        Self::from_json_value(value)
+    }
+}
+
+fn list_equals(lhs: &[Node], rhs: &[Node], options: &DiffOptions) -> bool {
+    if lhs.len() != rhs.len() {
+        return false;
+    }
+    lhs.iter().zip(rhs.iter()).all(|(a, b)| a.eq_with_options(b, options))
+}
+
+fn set_equals(lhs: &[Node], rhs: &[Node], options: &DiffOptions) -> bool {
+    let lhs_hashes: BTreeSet<HashCode> = lhs.iter().map(|n| n.hash_code(options)).collect();
+    let rhs_hashes: BTreeSet<HashCode> = rhs.iter().map(|n| n.hash_code(options)).collect();
+    lhs_hashes == rhs_hashes
+}
+
+fn multiset_equals(lhs: &[Node], rhs: &[Node], options: &DiffOptions) -> bool {
+    if lhs.len() != rhs.len() {
+        return false;
+    }
+    let mut counts = BTreeMap::new();
+    for hash in lhs.iter().map(|n| n.hash_code(options)) {
+        *counts.entry(hash).or_insert(0usize) += 1;
+    }
+    for hash in rhs.iter().map(|n| n.hash_code(options)) {
+        match counts.get_mut(&hash) {
+            Some(count) if *count > 0 => *count -= 1,
+            _ => return false,
+        }
+    }
+    counts.values().all(|count| *count == 0)
+}
+
+fn hash_list(values: &[Node], options: &DiffOptions) -> HashCode {
+    let mut bytes = Vec::with_capacity(8 + values.len() * 8);
+    bytes.extend_from_slice(&LIST_SEED);
+    for value in values {
+        bytes.extend_from_slice(&value.hash_code(options));
+    }
+    hash_bytes(&bytes)
+}
+
+fn hash_set(values: &[Node], options: &DiffOptions) -> HashCode {
+    let mut unique = BTreeSet::new();
+    for value in values {
+        unique.insert(value.hash_code(options));
+    }
+    combine(unique.into_iter().collect())
+}
+
+fn hash_multiset(values: &[Node], options: &DiffOptions) -> HashCode {
+    let hashes: Vec<_> = values.iter().map(|n| n.hash_code(options)).collect();
+    combine(hashes)
+}
+
+fn hash_object(map: &BTreeMap<String, Node>, options: &DiffOptions) -> HashCode {
+    let mut bytes = Vec::with_capacity(OBJECT_SEED.len() + map.len() * 16);
+    bytes.extend_from_slice(&OBJECT_SEED);
+    for (key, value) in map {
+        bytes.extend_from_slice(&hash_bytes(key.as_bytes()));
+        bytes.extend_from_slice(&value.hash_code(options));
+    }
+    hash_bytes(&bytes)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proptest::{
+        collection::{btree_map, vec},
+        prelude::*,
+        string::string_regex,
+    };
+
+    fn arb_json_value() -> impl Strategy<Value = JsonValue> {
+        let leaf = prop_oneof![
+            Just(JsonValue::Null),
+            any::<bool>().prop_map(JsonValue::Bool),
+            proptest::num::f64::ANY.prop_filter_map("finite", |f| {
+                if f.is_finite() {
+                    serde_json::Number::from_f64(f).map(JsonValue::Number)
+                } else {
+                    None
+                }
+            }),
+            string_regex("[a-zA-Z0-9]{0,8}").unwrap().prop_map(JsonValue::String),
+        ];
+        leaf.prop_recursive(4, 8, 4, move |inner| {
+            prop_oneof![
+                vec(inner.clone(), 0..4).prop_map(JsonValue::Array),
+                btree_map(string_regex("[a-zA-Z0-9]{1,8}").unwrap(), inner, 0..4).prop_map(|map| {
+                    let mut object = serde_json::Map::new();
+                    for (k, v) in map {
+                        object.insert(k, v);
+                    }
+                    JsonValue::Object(object)
+                }),
+            ]
+        })
+    }
+
+    #[test]
+    fn json_whitespace_is_void() {
+        let node = Node::from_json_str("   \n\t").expect("whitespace should canonicalize to void");
+        assert!(matches!(node, Node::Void));
+    }
+
+    #[test]
+    fn json_object_roundtrip() {
+        let node = Node::from_json_str("{\"a\":1,\"b\":true}").unwrap();
+        let value = node.to_json_value().unwrap();
+        assert_eq!(value["a"].as_f64().unwrap(), 1.0);
+        assert!(value["b"].as_bool().unwrap());
+    }
+
+    #[test]
+    fn json_number_out_of_range_yields_error() {
+        let err = Node::from_json_str("1e400").unwrap_err();
+        match err {
+            CanonicalizeError::NumberOutOfRange { .. } | CanonicalizeError::Json(_) => {}
+            other => panic!("unexpected error variant: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn yaml_non_string_key_errors() {
+        let err = Node::from_yaml_str("? [1, 2]: 3").unwrap_err();
+        let CanonicalizeError::NonStringYamlKey { .. } = err else {
+            panic!("expected NonStringYamlKey error");
+        };
+    }
+
+    #[test]
+    fn number_precision_controls_equality() {
+        let lhs = Node::from_json_str("1.0").unwrap();
+        let rhs = Node::from_json_str("1.05").unwrap();
+        let tight = DiffOptions::default();
+        assert!(!lhs.eq_with_options(&rhs, &tight));
+        let loose = DiffOptions::default().with_precision(0.1).unwrap();
+        assert!(lhs.eq_with_options(&rhs, &loose));
+    }
+
+    #[test]
+    fn array_mode_list_respects_order() {
+        let lhs = Node::from_json_str("[1,2]").unwrap();
+        let rhs = Node::from_json_str("[2,1]").unwrap();
+        let opts = DiffOptions::default();
+        assert!(!lhs.eq_with_options(&rhs, &opts));
+    }
+
+    #[test]
+    fn array_mode_set_ignores_order() {
+        let lhs = Node::from_json_str("[1,2]").unwrap();
+        let rhs = Node::from_json_str("[2,1]").unwrap();
+        let opts = DiffOptions::default().with_array_mode(ArrayMode::Set).unwrap();
+        assert!(lhs.eq_with_options(&rhs, &opts));
+    }
+
+    proptest! {
+        #[test]
+        fn json_roundtrips_through_node(value in arb_json_value()) {
+            let node = Node::from_json_value(value.clone()).unwrap();
+            let reconstructed = node.to_json_value().unwrap();
+            prop_assert_eq!(reconstructed.clone(), value);
+            let node_again = Node::from_json_value(reconstructed).unwrap();
+            prop_assert_eq!(node_again, node);
+        }
+    }
+}

--- a/crates/jd-core/src/number.rs
+++ b/crates/jd-core/src/number.rs
@@ -1,0 +1,50 @@
+use serde::{Deserialize, Serialize};
+
+use crate::{hash::hash_bytes, CanonicalizeError};
+
+/// Represents a JSON number using IEEE-754 double precision, mirroring Go's `float64`.
+#[derive(Clone, Copy, Debug, PartialOrd, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct Number(f64);
+
+impl Number {
+    /// Creates a new [`Number`] after validating finiteness.
+    ///
+    /// ```
+    /// # use jd_core::Number;
+    /// let num = Number::new(42.0)?;
+    /// assert_eq!(num.get(), 42.0);
+    /// # Ok::<(), jd_core::CanonicalizeError>(())
+    /// ```
+    pub fn new(value: f64) -> Result<Self, CanonicalizeError> {
+        if value.is_finite() {
+            Ok(Self(value))
+        } else {
+            Err(CanonicalizeError::NotFinite { value })
+        }
+    }
+
+    /// Returns the raw floating-point value.
+    #[must_use]
+    pub fn get(self) -> f64 {
+        self.0
+    }
+
+    /// Compares two numbers using the provided absolute tolerance.
+    #[must_use]
+    pub fn equals_with_precision(self, other: Self, precision: f64) -> bool {
+        (self.0 - other.0).abs() <= precision
+    }
+
+    /// Computes the hash code following the Go implementation's strategy.
+    #[must_use]
+    pub fn hash_code(self) -> crate::hash::HashCode {
+        hash_bytes(&self.0.to_le_bytes())
+    }
+}
+
+impl PartialEq for Number {
+    fn eq(&self, other: &Self) -> bool {
+        self.0 == other.0
+    }
+}

--- a/crates/jd-core/src/options.rs
+++ b/crates/jd-core/src/options.rs
@@ -1,0 +1,142 @@
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+use crate::OptionsError;
+
+/// Controls how arrays are interpreted during equality and diff operations.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ArrayMode {
+    /// Arrays behave as ordered lists (default).
+    List,
+    /// Arrays behave as mathematical sets (order-insensitive, unique elements).
+    Set,
+    /// Arrays behave as multisets (order-insensitive, duplicate-aware).
+    MultiSet,
+}
+
+impl Default for ArrayMode {
+    fn default() -> Self {
+        Self::List
+    }
+}
+
+/// Configuration knobs passed to equality and diff operations.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct DiffOptions {
+    array_mode: ArrayMode,
+    precision: f64,
+    set_keys: Option<Vec<String>>,
+}
+
+impl Default for DiffOptions {
+    fn default() -> Self {
+        Self { array_mode: ArrayMode::List, precision: 0.0, set_keys: None }
+    }
+}
+
+impl DiffOptions {
+    /// Returns the configured array interpretation mode.
+    #[must_use]
+    pub fn array_mode(&self) -> ArrayMode {
+        self.array_mode
+    }
+
+    /// Returns the numeric equality tolerance.
+    #[must_use]
+    pub fn precision(&self) -> f64 {
+        self.precision
+    }
+
+    /// Returns the keys used to identify objects within set semantics.
+    #[must_use]
+    pub fn set_keys(&self) -> Option<&[String]> {
+        self.set_keys.as_deref()
+    }
+
+    /// Sets the array interpretation mode.
+    pub fn with_array_mode(mut self, mode: ArrayMode) -> Result<Self, OptionsError> {
+        self.array_mode = mode;
+        self.validate()?;
+        Ok(self)
+    }
+
+    /// Sets the numeric precision tolerance.
+    pub fn with_precision(mut self, precision: f64) -> Result<Self, OptionsError> {
+        self.precision = precision;
+        self.validate()?;
+        Ok(self)
+    }
+
+    /// Sets the object identity keys used when arrays behave as sets.
+    pub fn with_set_keys<I, S>(mut self, keys: I) -> Result<Self, OptionsError>
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        let mut collected = Vec::new();
+        for key in keys {
+            let key = key.into();
+            if key.trim().is_empty() {
+                return Err(OptionsError::EmptySetKey);
+            }
+            collected.push(key);
+        }
+        if collected.is_empty() {
+            return Err(OptionsError::EmptySetKey);
+        }
+        collected.sort();
+        collected.dedup();
+        self.set_keys = Some(collected);
+        self.array_mode = ArrayMode::Set;
+        self.validate()?;
+        Ok(self)
+    }
+
+    fn validate(&self) -> Result<(), OptionsError> {
+        if !matches!(self.array_mode, ArrayMode::List) && self.precision > 0.0 {
+            return Err(OptionsError::PrecisionIncompatible);
+        }
+        if self.set_keys.is_some() && !matches!(self.array_mode, ArrayMode::Set) {
+            return Err(OptionsError::SetKeysRequireSetMode);
+        }
+        Ok(())
+    }
+}
+
+impl fmt::Display for ArrayMode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ArrayMode::List => f.write_str("list"),
+            ArrayMode::Set => f.write_str("set"),
+            ArrayMode::MultiSet => f.write_str("multiset"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn precision_and_set_mode_conflict() {
+        let err = DiffOptions::default()
+            .with_array_mode(ArrayMode::Set)
+            .and_then(|opts| opts.with_precision(0.1))
+            .unwrap_err();
+        assert_eq!(err, OptionsError::PrecisionIncompatible);
+    }
+
+    #[test]
+    fn set_keys_require_non_empty_strings() {
+        let err = DiffOptions::default().with_set_keys([" "]).unwrap_err();
+        assert_eq!(err, OptionsError::EmptySetKey);
+    }
+
+    #[test]
+    fn set_keys_force_set_mode() {
+        let opts = DiffOptions::default().with_set_keys(["id"]).unwrap();
+        assert_eq!(opts.array_mode(), ArrayMode::Set);
+        assert_eq!(opts.set_keys().unwrap(), ["id"]);
+    }
+}


### PR DESCRIPTION
## Summary
- add the jd-core canonical Node model with JSON/YAML parsing, equality, and hashing that mirror Go behaviour
- introduce Number, ArrayMode, DiffOptions, and dedicated error types to validate configuration combinations
- cover the new surface with unit/property doctests that exercise whitespace handling, numeric precision, and set semantics

## Testing
- cargo fmt
- cargo clippy -p jd-core --all-targets -- -D warnings
- cargo test -p jd-core


------
https://chatgpt.com/codex/tasks/task_e_68d5163da52083319c97c6a98df9e39e