### PR TITLE
Implement list-mode diff engine

### DIFF
--- a/crates/jd-core/src/diff/list.rs
+++ b/crates/jd-core/src/diff/list.rs
@@ -1,0 +1,200 @@
+use super::{diff_impl, Diff, DiffElement, Path, PathSegment};
+use crate::hash::HashCode;
+use crate::{DiffOptions, Node};
+
+pub(super) fn diff_lists(lhs: &[Node], rhs: &[Node], path: &Path, options: &DiffOptions) -> Diff {
+    let lhs_hashes: Vec<HashCode> = lhs.iter().map(|node| node.hash_code(options)).collect();
+    let rhs_hashes: Vec<HashCode> = rhs.iter().map(|node| node.hash_code(options)).collect();
+    let common = longest_common_subsequence(&lhs_hashes, &rhs_hashes);
+    let path_with_placeholder = path.clone().with_segment(PathSegment::index(0));
+    let elements = diff_rest(
+        lhs,
+        rhs,
+        0,
+        path_with_placeholder,
+        &lhs_hashes,
+        &rhs_hashes,
+        &common,
+        &Node::Void,
+        options,
+    );
+    Diff::from_elements(elements)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn diff_rest(
+    lhs: &[Node],
+    rhs: &[Node],
+    path_index: i64,
+    path: Path,
+    lhs_hashes: &[HashCode],
+    rhs_hashes: &[HashCode],
+    common: &[HashCode],
+    previous: &Node,
+    options: &DiffOptions,
+) -> Vec<DiffElement> {
+    let mut a_cursor = 0usize;
+    let mut b_cursor = 0usize;
+    let mut common_cursor = 0usize;
+    let mut path_cursor = path_index;
+    let path_len = path.len();
+
+    let mut diff = vec![DiffElement::new()
+        .with_path(path_now(&path, path_cursor))
+        .with_before(vec![previous.clone()])];
+
+    loop {
+        match () {
+            _ if a_cursor == lhs.len() => {
+                while b_cursor < rhs.len() {
+                    diff[0].add.push(rhs[b_cursor].clone());
+                    b_cursor += 1;
+                    path_cursor += 2;
+                }
+                break;
+            }
+            _ if b_cursor == rhs.len() => {
+                while a_cursor < lhs.len() {
+                    diff[0].remove.push(lhs[a_cursor].clone());
+                    a_cursor += 1;
+                }
+                break;
+            }
+            _ if at_common(lhs_hashes, a_cursor, common)
+                && at_common(rhs_hashes, b_cursor, common) =>
+            {
+                a_cursor += 1;
+                b_cursor += 1;
+                common_cursor += 1;
+                path_cursor += 1;
+                break;
+            }
+            _ if at_common(lhs_hashes, a_cursor, common) => {
+                while !at_common(rhs_hashes, b_cursor, common) {
+                    diff[0].add.push(rhs[b_cursor].clone());
+                    b_cursor += 1;
+                    path_cursor += 1;
+                }
+            }
+            _ if at_common(rhs_hashes, b_cursor, common) => {
+                while !at_common(lhs_hashes, a_cursor, common) {
+                    diff[0].remove.push(lhs[a_cursor].clone());
+                    a_cursor += 1;
+                }
+            }
+            _ if same_container_type(&lhs[a_cursor], &rhs[b_cursor]) => {
+                let sub_path = path_now(&path, path_cursor);
+                let mut sub_diff =
+                    diff_impl(&lhs[a_cursor], &rhs[b_cursor], &sub_path, options).into_elements();
+                if has_changes(&diff) {
+                    diff[0].after = after_context(lhs, a_cursor, common_cursor);
+                    diff.append(&mut sub_diff);
+                } else {
+                    diff = sub_diff;
+                }
+                a_cursor += 1;
+                b_cursor += 1;
+                path_cursor += 1;
+                break;
+            }
+            _ => {
+                diff[0].remove.push(lhs[a_cursor].clone());
+                diff[0].add.push(rhs[b_cursor].clone());
+                a_cursor += 1;
+                b_cursor += 1;
+                path_cursor += 1;
+            }
+        }
+    }
+
+    if !has_changes(&diff) {
+        diff.clear();
+    } else {
+        let single = diff.len() < 2;
+        if let Some(first) = diff.first_mut() {
+            if first.path.len() <= path_len && single {
+                first.after = after_context(lhs, a_cursor, common_cursor);
+            }
+        }
+    }
+
+    if a_cursor == lhs.len() && b_cursor == rhs.len() {
+        return diff;
+    }
+
+    let previous_node = if b_cursor == 0 { Node::Void } else { rhs[b_cursor - 1].clone() };
+    let mut rest = diff_rest(
+        &lhs[a_cursor..],
+        &rhs[b_cursor..],
+        path_cursor,
+        path_now(&path, path_cursor),
+        &lhs_hashes[a_cursor..],
+        &rhs_hashes[b_cursor..],
+        &common[common_cursor..],
+        &previous_node,
+        options,
+    );
+    diff.append(&mut rest);
+    diff
+}
+
+fn at_common(hashes: &[HashCode], cursor: usize, common: &[HashCode]) -> bool {
+    if cursor >= hashes.len() || common.is_empty() {
+        return false;
+    }
+    hashes[cursor] == common[0]
+}
+
+fn has_changes(diff: &[DiffElement]) -> bool {
+    diff.first()
+        .map(|element| !element.add.is_empty() || !element.remove.is_empty())
+        .unwrap_or(false)
+}
+
+fn after_context(lhs: &[Node], a_cursor: usize, common_cursor: usize) -> Vec<Node> {
+    let index = a_cursor.saturating_sub(common_cursor);
+    if index >= lhs.len() {
+        vec![Node::Void]
+    } else {
+        vec![lhs[index].clone()]
+    }
+}
+
+fn path_now(path: &Path, path_cursor: i64) -> Path {
+    path.drop_last().with_segment(PathSegment::index(path_cursor))
+}
+
+fn same_container_type(lhs: &Node, rhs: &Node) -> bool {
+    matches!(lhs, Node::Object(_)) && matches!(rhs, Node::Object(_))
+        || matches!(lhs, Node::Array(_)) && matches!(rhs, Node::Array(_))
+}
+
+fn longest_common_subsequence(lhs: &[HashCode], rhs: &[HashCode]) -> Vec<HashCode> {
+    let n = lhs.len();
+    let m = rhs.len();
+    let mut table = vec![vec![0usize; m + 1]; n + 1];
+    for i in (0..n).rev() {
+        for j in (0..m).rev() {
+            if lhs[i] == rhs[j] {
+                table[i][j] = table[i + 1][j + 1] + 1;
+            } else {
+                table[i][j] = table[i + 1][j].max(table[i][j + 1]);
+            }
+        }
+    }
+    let mut result = Vec::with_capacity(table[0][0]);
+    let mut i = 0usize;
+    let mut j = 0usize;
+    while i < n && j < m {
+        if lhs[i] == rhs[j] {
+            result.push(lhs[i]);
+            i += 1;
+            j += 1;
+        } else if table[i + 1][j] >= table[i][j + 1] {
+            i += 1;
+        } else {
+            j += 1;
+        }
+    }
+    result
+}

--- a/crates/jd-core/src/diff/mod.rs
+++ b/crates/jd-core/src/diff/mod.rs
@@ -1,0 +1,330 @@
+//! Diff data structures and algorithms.
+//!
+//! The module defines the native diff representation used by `jd-core` along
+//! with helper utilities for constructing, iterating, and serializing diffs.
+//! The current milestone implements list-mode diffing and object traversal,
+//! mirroring the upstream Go implementation.
+
+mod list;
+mod object;
+mod path;
+mod primitives;
+
+pub use path::{path_from_segments, root_path, Path, PathSegment};
+
+use serde::{Deserialize, Serialize};
+
+use crate::{ArrayMode, DiffOptions, Node};
+
+/// Metadata associated with a diff element.
+///
+/// ```
+/// # use jd_core::diff::DiffMetadata;
+/// let meta = DiffMetadata::merge();
+/// assert!(meta.merge);
+/// ```
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DiffMetadata {
+    /// Indicates that merge patch semantics should be used.
+    #[serde(default)]
+    pub merge: bool,
+}
+
+impl DiffMetadata {
+    /// Constructs metadata for merge mode.
+    #[must_use]
+    pub fn merge() -> Self {
+        Self { merge: true }
+    }
+}
+
+/// Represents a single diff hunk.
+///
+/// ```
+/// # use jd_core::diff::{DiffElement, PathSegment};
+/// # use jd_core::{Node, DiffOptions};
+/// let lhs = Node::from_json_str("1").unwrap();
+/// let rhs = Node::from_json_str("2").unwrap();
+/// let element = DiffElement::new()
+///     .with_path(vec![])
+///     .with_remove(vec![lhs.clone()])
+///     .with_add(vec![rhs.clone()]);
+/// assert_eq!(element.remove, vec![lhs.clone()]);
+/// assert_eq!(element.add, vec![rhs.clone()]);
+/// # let diff = lhs.diff(&rhs, &DiffOptions::default());
+/// # assert_eq!(diff.len(), 1);
+/// ```
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+pub struct DiffElement {
+    /// Optional metadata for this hunk.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<DiffMetadata>,
+    /// JSON Pointer-like path to the affected location.
+    #[serde(default)]
+    pub path: Path,
+    /// Context before the change (list diffs only).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub before: Vec<Node>,
+    /// Values removed at the path.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub remove: Vec<Node>,
+    /// Values added at the path.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub add: Vec<Node>,
+    /// Context after the change (list diffs only).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub after: Vec<Node>,
+}
+
+impl DiffElement {
+    /// Creates a blank diff element.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Sets the metadata for the element.
+    #[must_use]
+    pub fn with_metadata(mut self, metadata: DiffMetadata) -> Self {
+        self.metadata = Some(metadata);
+        self
+    }
+
+    /// Sets the path for the element.
+    #[must_use]
+    pub fn with_path<P>(mut self, path: P) -> Self
+    where
+        P: Into<Path>,
+    {
+        self.path = path.into();
+        self
+    }
+
+    /// Sets the before context.
+    #[must_use]
+    pub fn with_before(mut self, before: Vec<Node>) -> Self {
+        self.before = before;
+        self
+    }
+
+    /// Sets the removal list.
+    #[must_use]
+    pub fn with_remove(mut self, remove: Vec<Node>) -> Self {
+        self.remove = remove;
+        self
+    }
+
+    /// Sets the addition list.
+    #[must_use]
+    pub fn with_add(mut self, add: Vec<Node>) -> Self {
+        self.add = add;
+        self
+    }
+
+    /// Sets the after context.
+    #[must_use]
+    pub fn with_after(mut self, after: Vec<Node>) -> Self {
+        self.after = after;
+        self
+    }
+}
+
+/// Collection of diff elements.
+///
+/// ```
+/// # use jd_core::diff::{Diff, DiffElement};
+/// let diff = Diff::from_elements(vec![DiffElement::new()]);
+/// assert_eq!(diff.len(), 1);
+/// ```
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct Diff {
+    elements: Vec<DiffElement>,
+}
+
+impl Diff {
+    /// Constructs an empty diff.
+    #[must_use]
+    pub fn empty() -> Self {
+        Self { elements: Vec::new() }
+    }
+
+    /// Builds a diff from the provided elements.
+    #[must_use]
+    pub fn from_elements(elements: Vec<DiffElement>) -> Self {
+        Self { elements }
+    }
+
+    /// Returns the number of elements in the diff.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.elements.len()
+    }
+
+    /// Indicates whether the diff is empty.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.elements.is_empty()
+    }
+
+    /// Returns an iterator over the elements.
+    pub fn iter(&self) -> std::slice::Iter<'_, DiffElement> {
+        self.elements.iter()
+    }
+
+    /// Consumes the diff and returns the elements.
+    #[must_use]
+    pub fn into_elements(self) -> Vec<DiffElement> {
+        self.elements
+    }
+}
+
+impl IntoIterator for Diff {
+    type Item = DiffElement;
+    type IntoIter = std::vec::IntoIter<DiffElement>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.elements.into_iter()
+    }
+}
+
+impl<'a> IntoIterator for &'a Diff {
+    type Item = &'a DiffElement;
+    type IntoIter = std::slice::Iter<'a, DiffElement>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.elements.iter()
+    }
+}
+
+impl From<Vec<DiffElement>> for Diff {
+    fn from(value: Vec<DiffElement>) -> Self {
+        Self::from_elements(value)
+    }
+}
+
+/// Computes the structural diff between two nodes.
+#[must_use]
+pub fn diff_nodes(lhs: &Node, rhs: &Node, options: &DiffOptions) -> Diff {
+    diff_impl(lhs, rhs, &Path::new(), options)
+}
+
+pub(super) fn diff_impl(lhs: &Node, rhs: &Node, path: &Path, options: &DiffOptions) -> Diff {
+    if lhs.eq_with_options(rhs, options) {
+        return Diff::empty();
+    }
+
+    match (lhs, rhs) {
+        (Node::Object(left), Node::Object(right)) => {
+            object::diff_objects(left, right, path, options)
+        }
+        (Node::Array(left), Node::Array(right)) => match options.array_mode() {
+            ArrayMode::List => list::diff_lists(left, right, path, options),
+            mode => {
+                panic!("array mode {mode:?} not implemented in diff engine");
+            }
+        },
+        _ => primitives::diff_primitives(lhs, rhs, path),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::DiffOptions;
+    use proptest::prelude::*;
+
+    #[test]
+    fn diff_of_numbers_produces_replacement_hunk() {
+        let lhs = Node::from_json_str("1").unwrap();
+        let rhs = Node::from_json_str("2").unwrap();
+        let diff = diff_nodes(&lhs, &rhs, &DiffOptions::default());
+        let expected = Diff::from_elements(vec![DiffElement::new()
+            .with_path(Path::new())
+            .with_remove(vec![lhs])
+            .with_add(vec![rhs])]);
+        assert_eq!(diff, expected);
+    }
+
+    #[test]
+    fn diff_of_objects_tracks_additions_and_removals() {
+        let lhs = Node::from_json_str("{\"a\":1,\"b\":2}").unwrap();
+        let rhs = Node::from_json_str("{\"b\":2,\"c\":3}").unwrap();
+        let diff = diff_nodes(&lhs, &rhs, &DiffOptions::default());
+        let expected = Diff::from_elements(vec![
+            DiffElement::new()
+                .with_path(PathSegment::key("a"))
+                .with_remove(vec![Node::from_json_str("1").unwrap()]),
+            DiffElement::new()
+                .with_path(PathSegment::key("c"))
+                .with_add(vec![Node::from_json_str("3").unwrap()]),
+        ]);
+        assert_eq!(diff, expected);
+    }
+
+    #[test]
+    fn diff_of_arrays_with_substitution_preserves_context() {
+        let lhs = Node::from_json_str("[1,2,3]").unwrap();
+        let rhs = Node::from_json_str("[1,4,3]").unwrap();
+        let diff = diff_nodes(&lhs, &rhs, &DiffOptions::default());
+        let expected = Diff::from_elements(vec![DiffElement::new()
+            .with_path(Path::from(vec![PathSegment::index(1)]))
+            .with_before(vec![Node::from_json_str("1").unwrap()])
+            .with_remove(vec![Node::from_json_str("2").unwrap()])
+            .with_add(vec![Node::from_json_str("4").unwrap()])
+            .with_after(vec![Node::from_json_str("3").unwrap()])]);
+        assert_eq!(diff, expected);
+    }
+
+    #[test]
+    fn diff_of_arrays_with_append_marks_void_context() {
+        let lhs = Node::from_json_str("[1,2]").unwrap();
+        let rhs = Node::from_json_str("[1,2,3]").unwrap();
+        let diff = diff_nodes(&lhs, &rhs, &DiffOptions::default());
+        let expected = Diff::from_elements(vec![DiffElement::new()
+            .with_path(Path::from(vec![PathSegment::index(2)]))
+            .with_before(vec![Node::from_json_str("2").unwrap()])
+            .with_add(vec![Node::from_json_str("3").unwrap()])
+            .with_after(vec![Node::Void])]);
+        assert_eq!(diff, expected);
+    }
+
+    fn arb_json_value() -> impl Strategy<Value = serde_json::Value> {
+        use proptest::{collection::btree_map, collection::vec, string::string_regex};
+
+        let leaf = prop_oneof![
+            Just(serde_json::Value::Null),
+            any::<bool>().prop_map(serde_json::Value::Bool),
+            proptest::num::f64::ANY.prop_filter_map("finite", |f| {
+                if f.is_finite() {
+                    serde_json::Number::from_f64(f).map(serde_json::Value::Number)
+                } else {
+                    None
+                }
+            }),
+            string_regex("[a-zA-Z0-9]{0,8}").unwrap().prop_map(serde_json::Value::String),
+        ];
+        leaf.prop_recursive(4, 8, 4, move |inner| {
+            prop_oneof![
+                vec(inner.clone(), 0..4).prop_map(serde_json::Value::Array),
+                btree_map(string_regex("[a-zA-Z0-9]{1,8}").unwrap(), inner, 0..4).prop_map(|map| {
+                    let mut object = serde_json::Map::new();
+                    for (k, v) in map {
+                        object.insert(k, v);
+                    }
+                    serde_json::Value::Object(object)
+                }),
+            ]
+        })
+    }
+
+    proptest! {
+        #[test]
+        fn identical_nodes_produce_empty_diff(json in arb_json_value()) {
+            let node = Node::from_json_value(json.clone()).unwrap();
+            let other = Node::from_json_value(json).unwrap();
+            let diff = diff_nodes(&node, &other, &DiffOptions::default());
+            prop_assert!(diff.is_empty());
+        }
+    }
+}

--- a/crates/jd-core/src/diff/object.rs
+++ b/crates/jd-core/src/diff/object.rs
@@ -1,0 +1,43 @@
+use std::collections::BTreeMap;
+
+use super::{diff_impl, Diff, DiffElement, Path, PathSegment};
+use crate::{DiffOptions, Node};
+
+pub(super) fn diff_objects(
+    lhs: &BTreeMap<String, Node>,
+    rhs: &BTreeMap<String, Node>,
+    path: &Path,
+    options: &DiffOptions,
+) -> Diff {
+    let mut elements = Vec::new();
+
+    let mut lhs_keys: Vec<_> = lhs.keys().cloned().collect();
+    lhs_keys.sort();
+    for key in lhs_keys {
+        let value = &lhs[&key];
+        if let Some(other) = rhs.get(&key) {
+            let sub_path = path.clone().with_segment(PathSegment::key(key));
+            let diff = diff_impl(value, other, &sub_path, options);
+            elements.extend(diff.into_iter());
+        } else {
+            let element = DiffElement::new()
+                .with_path(path.clone().with_segment(PathSegment::key(key)))
+                .with_remove(vec![value.clone()]);
+            elements.push(element);
+        }
+    }
+
+    let mut rhs_keys: Vec<_> = rhs.keys().cloned().collect();
+    rhs_keys.sort();
+    for key in rhs_keys {
+        if lhs.contains_key(&key) {
+            continue;
+        }
+        let element = DiffElement::new()
+            .with_path(path.clone().with_segment(PathSegment::key(key.clone())))
+            .with_add(vec![rhs[&key].clone()]);
+        elements.push(element);
+    }
+
+    Diff::from_elements(elements)
+}

--- a/crates/jd-core/src/diff/path.rs
+++ b/crates/jd-core/src/diff/path.rs
@@ -1,0 +1,229 @@
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+/// Represents a single element within a diff path.
+///
+/// A segment can either refer to an object key or an array index. Future
+/// milestones will add set and multiset markers.
+///
+/// ```
+/// # use jd_core::diff::PathSegment;
+/// let key = PathSegment::key("name");
+/// let index = PathSegment::index(2);
+/// assert!(matches!(key, PathSegment::Key(_)));
+/// assert!(matches!(index, PathSegment::Index(_)));
+/// ```
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub enum PathSegment {
+    /// Object key lookup.
+    Key(String),
+    /// Array index lookup.
+    Index(i64),
+}
+
+impl PathSegment {
+    /// Creates a key segment.
+    #[must_use]
+    pub fn key<S>(value: S) -> Self
+    where
+        S: Into<String>,
+    {
+        Self::Key(value.into())
+    }
+
+    /// Creates an index segment.
+    #[must_use]
+    pub fn index<I>(value: I) -> Self
+    where
+        I: Into<i64>,
+    {
+        Self::Index(value.into())
+    }
+}
+
+impl Serialize for PathSegment {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match self {
+            Self::Key(key) => serializer.serialize_str(key),
+            Self::Index(index) => serializer.serialize_i64(*index),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for PathSegment {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct Visitor;
+
+        impl<'de> serde::de::Visitor<'de> for Visitor {
+            type Value = PathSegment;
+
+            fn expecting(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                f.write_str("a string key or integer index")
+            }
+
+            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                Ok(PathSegment::Key(v.to_owned()))
+            }
+
+            fn visit_string<E>(self, v: String) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                Ok(PathSegment::Key(v))
+            }
+
+            fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                Ok(PathSegment::Index(v))
+            }
+
+            fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                let value = i64::try_from(v).map_err(|_| E::custom("index exceeds i64"))?;
+                Ok(PathSegment::Index(value))
+            }
+        }
+
+        deserializer.deserialize_any(Visitor)
+    }
+}
+
+/// Represents the fully qualified location of a diff hunk within a document.
+///
+/// ```
+/// # use jd_core::diff::{Path, PathSegment};
+/// let path = Path::new().with_segment(PathSegment::key("foo"))
+///     .with_segment(PathSegment::index(0));
+/// assert_eq!(path.len(), 2);
+/// ```
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct Path(Vec<PathSegment>);
+
+impl Path {
+    /// Creates an empty path.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Appends a new segment, returning the extended path.
+    #[must_use]
+    pub fn with_segment(mut self, segment: PathSegment) -> Self {
+        self.0.push(segment);
+        self
+    }
+
+    /// Returns the underlying segments.
+    #[must_use]
+    pub fn segments(&self) -> &[PathSegment] {
+        &self.0
+    }
+
+    /// Returns the number of segments.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Indicates whether the path is empty.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// Returns a new path with the last segment removed, if any.
+    #[must_use]
+    pub fn drop_last(&self) -> Self {
+        let mut segments = self.0.clone();
+        segments.pop();
+        Self(segments)
+    }
+
+    /// Consumes the path and returns the owned segments.
+    #[must_use]
+    pub fn into_segments(self) -> Vec<PathSegment> {
+        self.0
+    }
+
+    /// Pushes a new segment in-place.
+    pub fn push(&mut self, segment: PathSegment) {
+        self.0.push(segment);
+    }
+
+    /// Pops the last segment off the path.
+    pub fn pop(&mut self) -> Option<PathSegment> {
+        self.0.pop()
+    }
+}
+
+impl From<Vec<PathSegment>> for Path {
+    fn from(value: Vec<PathSegment>) -> Self {
+        Self(value)
+    }
+}
+
+impl From<PathSegment> for Path {
+    fn from(value: PathSegment) -> Self {
+        Self(vec![value])
+    }
+}
+
+impl<'a> IntoIterator for &'a Path {
+    type Item = &'a PathSegment;
+    type IntoIter = std::slice::Iter<'a, PathSegment>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.iter()
+    }
+}
+
+impl IntoIterator for Path {
+    type Item = PathSegment;
+    type IntoIter = std::vec::IntoIter<PathSegment>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
+/// Creates a path representing the root of a document.
+#[must_use]
+pub fn root_path() -> Path {
+    Path::new()
+}
+
+/// Builds a path from an iterator of segments.
+#[must_use]
+pub fn path_from_segments<I>(segments: I) -> Path
+where
+    I: IntoIterator<Item = PathSegment>,
+{
+    Path(segments.into_iter().collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn serde_round_trip_for_key_segments() {
+        let path = path_from_segments([PathSegment::key("foo"), PathSegment::index(3)]);
+        let json = serde_json::to_string(&path).unwrap();
+        assert_eq!(json, "[\"foo\",3]");
+        let decoded: Path = serde_json::from_str(&json).unwrap();
+        assert_eq!(decoded, path);
+    }
+}

--- a/crates/jd-core/src/diff/primitives.rs
+++ b/crates/jd-core/src/diff/primitives.rs
@@ -1,0 +1,15 @@
+use super::{Diff, DiffElement, Path};
+use crate::Node;
+
+/// Produces a replacement diff element for non-container nodes.
+#[allow(clippy::needless_pass_by_value)]
+pub(super) fn diff_primitives(lhs: &Node, rhs: &Node, path: &Path) -> Diff {
+    let mut element = DiffElement::new().with_path(path.clone());
+    if !matches!(lhs, Node::Void) {
+        element.remove.push(lhs.clone());
+    }
+    if !matches!(rhs, Node::Void) {
+        element.add.push(rhs.clone());
+    }
+    Diff::from_elements(vec![element])
+}

--- a/crates/jd-core/src/lib.rs
+++ b/crates/jd-core/src/lib.rs
@@ -20,12 +20,14 @@
 #![forbid(unsafe_code)]
 #![warn(missing_docs)]
 
+pub mod diff;
 mod error;
 mod hash;
 mod node;
 mod number;
 mod options;
 
+pub use diff::{Diff, DiffElement, DiffMetadata, Path, PathSegment};
 pub use error::{CanonicalizeError, OptionsError};
 pub use node::Node;
 pub use number::Number;

--- a/crates/jd-core/src/node.rs
+++ b/crates/jd-core/src/node.rs
@@ -215,6 +215,20 @@ impl Node {
         }
     }
 
+    /// Computes the structural diff between two nodes.
+    ///
+    /// ```
+    /// # use jd_core::{DiffOptions, Node};
+    /// let lhs = Node::from_json_str("1").unwrap();
+    /// let rhs = Node::from_json_str("2").unwrap();
+    /// let diff = lhs.diff(&rhs, &DiffOptions::default());
+    /// assert_eq!(diff.len(), 1);
+    /// ```
+    #[must_use]
+    pub fn diff(&self, other: &Self, options: &DiffOptions) -> crate::Diff {
+        crate::diff::diff_nodes(self, other, options)
+    }
+
     /// Computes the Go-compatible hash code for this node.
     #[must_use]
     pub fn hash_code(&self, options: &DiffOptions) -> HashCode {

--- a/crates/jd-core/tests/diff_golden.rs
+++ b/crates/jd-core/tests/diff_golden.rs
@@ -1,0 +1,42 @@
+use std::fs;
+use std::path::Path;
+
+use jd_core::{Diff, DiffOptions, Node};
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize)]
+struct Fixture {
+    lhs: String,
+    rhs: String,
+    diff: Diff,
+}
+
+fn load_fixture(path: &Path) -> Fixture {
+    let data = fs::read_to_string(path).expect("fixture should be readable");
+    serde_json::from_str(&data).expect("fixture should deserialize")
+}
+
+#[test]
+fn list_mode_golden_parity() {
+    let fixtures_root = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/diff/list");
+    let mut entries: Vec<_> = fs::read_dir(&fixtures_root)
+        .expect("fixtures directory must exist")
+        .filter_map(|entry| entry.ok())
+        .map(|entry| entry.path())
+        .filter(|path| path.extension().is_some_and(|ext| ext == "json"))
+        .collect();
+    entries.sort();
+
+    assert!(
+        !entries.is_empty(),
+        "expected at least one diff fixture under tests/fixtures/diff/list",
+    );
+
+    for path in entries {
+        let fixture = load_fixture(&path);
+        let lhs = Node::from_json_str(&fixture.lhs).expect("lhs parses");
+        let rhs = Node::from_json_str(&fixture.rhs).expect("rhs parses");
+        let diff = lhs.diff(&rhs, &DiffOptions::default());
+        assert_eq!(diff, fixture.diff, "fixture {path:?}");
+    }
+}

--- a/crates/jd-core/tests/fixtures/diff/list/append.json
+++ b/crates/jd-core/tests/fixtures/diff/list/append.json
@@ -1,0 +1,29 @@
+{
+  "lhs": "[1,2]",
+  "rhs": "[1,2,3]",
+  "diff": [
+    {
+      "path": [
+        2
+      ],
+      "before": [
+        {
+          "type": "Number",
+          "value": 2
+        }
+      ],
+      "remove": [],
+      "add": [
+        {
+          "type": "Number",
+          "value": 3
+        }
+      ],
+      "after": [
+        {
+          "type": "Void"
+        }
+      ]
+    }
+  ]
+}

--- a/crates/jd-core/tests/fixtures/diff/list/removal.json
+++ b/crates/jd-core/tests/fixtures/diff/list/removal.json
@@ -1,0 +1,29 @@
+{
+  "lhs": "[1,2,3]",
+  "rhs": "[1,2]",
+  "diff": [
+    {
+      "path": [
+        2
+      ],
+      "before": [
+        {
+          "type": "Number",
+          "value": 2
+        }
+      ],
+      "remove": [
+        {
+          "type": "Number",
+          "value": 3
+        }
+      ],
+      "add": [],
+      "after": [
+        {
+          "type": "Void"
+        }
+      ]
+    }
+  ]
+}

--- a/crates/jd-core/tests/fixtures/diff/list/substitution.json
+++ b/crates/jd-core/tests/fixtures/diff/list/substitution.json
@@ -1,0 +1,35 @@
+{
+  "lhs": "[1,2,3]",
+  "rhs": "[1,4,3]",
+  "diff": [
+    {
+      "path": [
+        1
+      ],
+      "before": [
+        {
+          "type": "Number",
+          "value": 1
+        }
+      ],
+      "remove": [
+        {
+          "type": "Number",
+          "value": 2
+        }
+      ],
+      "add": [
+        {
+          "type": "Number",
+          "value": 4
+        }
+      ],
+      "after": [
+        {
+          "type": "Number",
+          "value": 3
+        }
+      ]
+    }
+  ]
+}

--- a/docs/specs/diff-engine-mvp.md
+++ b/docs/specs/diff-engine-mvp.md
@@ -1,0 +1,81 @@
+# Diff Engine MVP Specification
+
+## Scope
+- Implement the structural diff for `ArrayMode::List` across all node variants in `jd-core`.
+- Provide typed representations for diffs (`Diff`, `DiffElement`), metadata, and path segments compatible with Go `jd` v2.2.2 native format.
+- Introduce internal helpers for Myers-style LCS alignment used by list diffs, including deterministic tie-breaking to match Go output ordering.
+- Expose parsing/serialization shims sufficient for test fixtures (full renderers ship in later milestones).
+
+## Module Layout
+- `crates/jd-core/src/diff/mod.rs` – public entry points (`diff`, `Diff`, `DiffElement`), plus serde support for the native format used in goldens.
+- `crates/jd-core/src/diff/path.rs` – `PathSegment` enum (Key, Index, Set, SetKeys placeholder), cloning helpers, equality, and formatting for debug/testing.
+- `crates/jd-core/src/diff/list.rs` – list diff implementation with LCS, cursor walk, context capture, and recursion into child nodes.
+- `crates/jd-core/src/diff/object.rs` – object diff implementation (lexical key ordering, recursion, add/remove hunks).
+- `crates/jd-core/src/diff/primitives.rs` – fallbacks for scalar mismatches leveraging `Node::eq_with_options` and `Node::hash_code`.
+- Future milestones will extend this tree with set/multiset support and renderers; keep APIs internal or `pub(crate)` when possible until stabilized via ADR.
+
+## Data Structures
+- `DiffMetadata` struct mirroring Go's `Metadata` (fields: `merge: bool`, `set_keys: Option<Vec<String>>`, `color: Option<bool>>` placeholder for future). Only `merge` is required for list-mode MVP.
+- `DiffElement` struct containing:
+  - `metadata: Option<DiffMetadata>` (only serialized when Some).
+  - `path: Vec<PathSegment>`.
+  - `before: Vec<Node>` and `after: Vec<Node>` (list context).
+  - `remove: Vec<Node>` and `add: Vec<Node>`.
+- `Diff` type aliasing `Vec<DiffElement>` with constructor helpers (`Diff::empty`, `Diff::singleton`).
+- `PathSegment` enum supporting `Key(String)` and `Index(i64)` for MVP, plus `Set`, `SetKeys(BTreeMap<_, _>)`, etc., stubbed but unimplemented operations returning errors when used.
+
+## Algorithm Details
+### Common Flow
+1. Entry point `Node::diff(&self, other, options: &DiffOptions) -> Diff` delegates based on enum variant.
+2. If nodes are equal under options, return empty diff.
+3. When variants differ, emit a replacement hunk containing `remove` (old) and `add` (new) arrays; list/object variants call specialized logic first.
+
+### Primitive Nodes (`Void`, `Null`, `Bool`, `Number`, `String`)
+- On mismatch, emit a single hunk with `path` being the current path, `remove` containing `self.clone()` (unless `Void`), and `add` containing `other.clone()`.
+- `before`/`after` remain empty.
+
+### Objects (`Node::Object`)
+- Gather keys from both objects, sort lexicographically, and iterate once for removals (keys only in left) and additions (keys only in right).
+- When key exists in both maps, recursively diff child nodes with path extended by `PathSegment::Key(key.clone())`.
+- For keys missing from RHS, emit hunk with `remove=[old]`, `add=[]`.
+- For keys missing from LHS, emit hunk with `remove=[]`, `add=[new]`.
+- Merge metadata is hard-coded to `merge=false` for MVP; future toggles will set it based on `DiffOptions`.
+
+### Arrays (`Node::Array`) – List Mode
+1. Compute hash codes for each element using `Node::hash_code(options)`.
+2. Run Myers LCS on the hash sequences; we will implement a deterministic LCS variant that favors earlier elements (mirroring Go's usage of `golcs`).
+3. Walk the arrays with cursors `i` (lhs), `j` (rhs), `lcs_idx` (common sequence index), and maintain `path_cursor` representing the insertion index in diff path semantics.
+4. Accumulate pending hunk data:
+   - `before` seeded with the previous RHS element (or `Void` when at start).
+   - `remove` appended when advancing lhs without matching LCS.
+   - `add` appended when advancing rhs without matching LCS.
+5. When encountering nested containers of compatible types, flush pending context (`after` = next lhs element or `Void`) before recursing and appending the nested diff to the result list.
+6. When reaching end-of-array conditions, flush remaining `add` or `remove` entries accordingly and set `after` to trailing context if needed.
+7. Recursively continue with remaining suffix by calling `diff_rest` equivalent until both arrays consumed.
+
+### Path Semantics
+- For list diffs, the first hunk path is parent path plus `PathSegment::Index(start_index)` representing the insertion point. Each recursion increments `path_cursor` consistent with Go's behavior (increments by 2 when only additions appended, by 1 otherwise).
+- For object diffs, paths simply append `PathSegment::Key` for nested traversal.
+- Provide helper to `clone_drop_last` mirroring Go's `path.clone().drop()` when building nested contexts.
+
+## Testing Strategy
+- **Unit tests** (`crates/jd-core/src/diff/...`) covering:
+  - Replacement hunks for scalar mismatches.
+  - Object diff scenarios: key removal, addition, nested recursion.
+  - Array diff cases: pure insert, pure delete, substitution, nested object diff inline.
+- **Property tests** verifying that diff is empty when nodes equal and that `diff` respects array equality invariants.
+- **Golden tests** under `crates/jd-core/tests/fixtures/diff/list/` comparing Rust-rendered diffs (serialized JSON) against outputs generated by Go `jd` for curated fixtures (simple arrays, nested objects, multiple operations).
+- **CLI integration** (`tests/cli/diff_basic.rs`) to invoke `jd-cli diff` with fixtures and compare stdout/stderr/exit code to golden expectations.
+
+## Dependencies
+- Introduce a small, `no_std`-friendly Myers LCS helper under `jd-core` rather than external crates to keep control over determinism.
+- No new external dependencies required for MVP; reuse existing serde/test stacks.
+
+## Out of Scope / Deferred
+- Set and multiset modes, metadata flags (`set`, `mset`, `setkeys`).
+- Rendering diffs into CLI formats (native, JSON Patch, etc.).
+- Patch application logic, merge semantics toggles.
+- Performance tuning beyond straightforward iteration.
+
+## Open Questions
+- Validate whether Go's `golcs` tie-breaking always prefers earliest matches; confirm by running targeted fixtures when generating goldens. If discrepancies arise, document in ADR.


### PR DESCRIPTION
## Summary
- add jd-core diff module with diff metadata, elements, and path utilities
- implement list-mode diff and object diff traversal with LCS alignment and primitive fallback
- add golden fixtures, property/unit tests, and diff spec/status update for milestone 4

## Testing
- cargo fmt --all
- cargo clippy --workspace --all-targets --all-features
- cargo test --all-targets

------
https://chatgpt.com/codex/tasks/task_e_68d51b994b308331a691b4b26c185f03