### PR TITLE
Implement patch application engine

### DIFF
--- a/ADRs/0001-clarify-test-flag.md
+++ b/ADRs/0001-clarify-test-flag.md
@@ -1,0 +1,25 @@
+# 0001 — Clarify `-test` Flag Expectation
+
+## Status
+Accepted
+
+## Context
+The implementation plan (Milestone 6) calls for "reverse operation for `-test` flag parity" and later wiring a CLI `-test` flag. After re-reading the upstream Go CLI (`v2.2.2`), there is no `-test` option—flags are limited to the set enumerated in `main.go` (`-color`, `-f`, `-git-diff-driver`, `-mset`, `-o`, `-p`, `-port`, `-precision`, `-set`, `-setkeys`, `-t`, `-version`, `-yaml`, `-v2`).【074fa5†L23-L199】 The only `-test` usage in the repository refers to Go's testing harness (e.g., `-test.run`) rather than user-facing CLI behavior. The milestone requirement therefore conflicts with the parity constraint.
+
+## Decision
+Treat the plan's reference to a `-test` flag as an internal shorthand for validating patch reversibility rather than a public CLI flag. We will:
+- Implement `Diff::reverse` within `jd-core` to support automated round-trip validation.
+- Keep the CLI surface aligned with Go (`jd` will not expose a `-test` flag unless upstream adds one).
+- Document this interpretation in milestone status updates to avoid future confusion.
+
+## Alternatives Considered
+- **Implement a new `-test` flag anyway:** Rejected because it would violate the parity guardrail and add unsupported behavior.
+- **Ignore reverse functionality entirely:** Rejected; the milestone still benefits from a library-level reverse helper used by tests and potential future parity scripts.
+
+## Consequences
+- Subsequent milestones can rely on `Diff::reverse` for invariants without exposing new CLI options.
+- Any future upstream changes introducing a real `-test` flag will require revisiting this ADR.
+
+## References
+- Go CLI flag definitions in `v2.2.2/v2/jd/main.go`.【074fa5†L23-L199】
+- Implementation plan requirement in `docs/implementation_plan.md`.【4be4c3†L1-L2】

--- a/crates/jd-core/src/diff/path.rs
+++ b/crates/jd-core/src/diff/path.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 /// Represents a single element within a diff path.
@@ -37,6 +39,15 @@ impl PathSegment {
         I: Into<i64>,
     {
         Self::Index(value.into())
+    }
+}
+
+impl fmt::Display for PathSegment {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Key(key) => f.write_str(key),
+            Self::Index(index) => write!(f, "{}", index),
+        }
     }
 }
 
@@ -178,6 +189,19 @@ impl From<Vec<PathSegment>> for Path {
 impl From<PathSegment> for Path {
     fn from(value: PathSegment) -> Self {
         Self(vec![value])
+    }
+}
+
+impl fmt::Display for Path {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("[")?;
+        for (idx, segment) in self.0.iter().enumerate() {
+            if idx > 0 {
+                f.write_str(" ")?;
+            }
+            write!(f, "{}", segment)?;
+        }
+        f.write_str("]")
     }
 }
 

--- a/crates/jd-core/src/lib.rs
+++ b/crates/jd-core/src/lib.rs
@@ -26,12 +26,14 @@ mod hash;
 mod node;
 mod number;
 mod options;
+mod patch;
 
-pub use diff::{Diff, DiffElement, DiffMetadata, Path, PathSegment};
+pub use diff::{Diff, DiffElement, DiffMetadata, Path, PathSegment, RenderConfig, RenderError};
 pub use error::{CanonicalizeError, OptionsError};
 pub use node::Node;
 pub use number::Number;
 pub use options::{ArrayMode, DiffOptions};
+pub use patch::PatchError;
 
 /// Returns the semantic version of the `jd-core` crate.
 ///

--- a/crates/jd-core/src/node.rs
+++ b/crates/jd-core/src/node.rs
@@ -6,7 +6,7 @@ use serde_yaml::Value as YamlValue;
 
 use crate::{
     hash::{combine, hash_bytes, HashCode},
-    ArrayMode, CanonicalizeError, DiffOptions, Number,
+    ArrayMode, CanonicalizeError, DiffOptions, Number, PatchError,
 };
 
 const VOID_HASH: HashCode = [0xF3, 0x97, 0x6B, 0x21, 0x91, 0x26, 0x8D, 0x96];
@@ -227,6 +227,21 @@ impl Node {
     #[must_use]
     pub fn diff(&self, other: &Self, options: &DiffOptions) -> crate::Diff {
         crate::diff::diff_nodes(self, other, options)
+    }
+
+    /// Applies a diff to this node, returning the patched node on success.
+    ///
+    /// ```
+    /// # use jd_core::{DiffOptions, Node};
+    /// let base = Node::from_json_str("[1,2,3]")?;
+    /// let target = Node::from_json_str("[1,4,3]")?;
+    /// let diff = base.diff(&target, &DiffOptions::default());
+    /// let patched = base.apply_patch(&diff)?;
+    /// assert_eq!(patched, target);
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    pub fn apply_patch(&self, diff: &crate::Diff) -> Result<Self, PatchError> {
+        crate::patch::apply_patch(self, diff)
     }
 
     /// Computes the Go-compatible hash code for this node.

--- a/crates/jd-core/src/patch.rs
+++ b/crates/jd-core/src/patch.rs
@@ -1,0 +1,515 @@
+//! Patch application engine for jd diffs.
+//!
+//! The implementation follows the semantics of the upstream Go version by
+//! interpreting `DiffElement` metadata, enforcing list context validation, and
+//! recursing through objects and arrays using strict or merge strategies.
+
+use std::collections::BTreeMap;
+use std::fmt;
+
+use crate::{
+    diff::{Path, PathSegment},
+    Diff, DiffMetadata, Node,
+};
+
+/// Errors that can occur while applying a diff.
+///
+/// ```
+/// # use jd_core::{DiffOptions, Node};
+/// let base = Node::from_json_str("[1,2,3]").unwrap();
+/// let target = Node::from_json_str("[1,4,3]").unwrap();
+/// let diff = base.diff(&target, &DiffOptions::default());
+/// let err = Node::from_json_str("[0,2,3]").unwrap().apply_patch(&diff).unwrap_err();
+/// assert_eq!(err.to_string(), "invalid patch. expected 1 before. got 0");
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PatchError {
+    message: String,
+}
+
+impl PatchError {
+    fn new(message: impl Into<String>) -> Self {
+        Self { message: message.into() }
+    }
+}
+
+impl fmt::Display for PatchError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for PatchError {}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum PatchStrategy {
+    Strict,
+    Merge,
+}
+
+impl PatchStrategy {
+    fn from_metadata(metadata: Option<&DiffMetadata>) -> Self {
+        if metadata.map_or(false, |m| m.merge) {
+            Self::Merge
+        } else {
+            Self::Strict
+        }
+    }
+}
+
+impl fmt::Display for PatchStrategy {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Strict => f.write_str("strict"),
+            Self::Merge => f.write_str("merge"),
+        }
+    }
+}
+
+pub(crate) fn apply_patch(node: &Node, diff: &Diff) -> Result<Node, PatchError> {
+    let mut current = node.clone();
+    let mut inherited_metadata: Option<DiffMetadata> = None;
+    for element in diff.iter() {
+        if let Some(meta) = element.metadata.as_ref() {
+            inherited_metadata = Some(meta.clone());
+        }
+        let metadata = element.metadata.as_ref().or(inherited_metadata.as_ref());
+        let strategy = PatchStrategy::from_metadata(metadata);
+        current = patch_element(
+            current,
+            Vec::new(),
+            element.path.segments(),
+            &element.before,
+            &element.remove,
+            &element.add,
+            &element.after,
+            strategy,
+        )?;
+    }
+    Ok(current)
+}
+
+fn patch_element(
+    node: Node,
+    path_behind: Vec<PathSegment>,
+    path_ahead: &[PathSegment],
+    before: &[Node],
+    remove: &[Node],
+    add: &[Node],
+    after: &[Node],
+    strategy: PatchStrategy,
+) -> Result<Node, PatchError> {
+    if !path_ahead.is_empty() && strategy == PatchStrategy::Merge {
+        let (segment, rest) = path_ahead.split_first().unwrap();
+        let PathSegment::Key(key) = segment else {
+            return Err(expected_collection_error(&node, segment));
+        };
+
+        match node {
+            Node::Object(mut map) => {
+                let existing = map.remove(key).unwrap_or_else(|| {
+                    if rest.is_empty() {
+                        Node::Void
+                    } else {
+                        Node::Object(BTreeMap::new())
+                    }
+                });
+                let mut new_path = path_behind.clone();
+                new_path.push(PathSegment::Key(key.clone()));
+                let patched =
+                    patch_element(existing, new_path, rest, before, remove, add, after, strategy)?;
+                if is_void(&patched) && rest.is_empty() {
+                    // Removal handled via map.remove above.
+                } else if !is_void(&patched) || !rest.is_empty() {
+                    map.insert(key.clone(), patched);
+                }
+                return Ok(Node::Object(map));
+            }
+            _other => {
+                let seed = if rest.is_empty() { Node::Void } else { Node::Object(BTreeMap::new()) };
+                let mut new_path = path_behind.clone();
+                new_path.push(PathSegment::Key(key.clone()));
+                let patched =
+                    patch_element(seed, new_path, rest, before, remove, add, after, strategy)?;
+                let mut map = BTreeMap::new();
+                if !is_void(&patched) || !rest.is_empty() {
+                    map.insert(key.clone(), patched);
+                }
+                return Ok(Node::Object(map));
+            }
+        }
+    }
+
+    match node {
+        Node::Array(values) => {
+            patch_list(values, path_behind, path_ahead, before, remove, add, after, strategy)
+        }
+        Node::Object(map) => {
+            patch_object(map, path_behind, path_ahead, before, remove, add, after, strategy)
+        }
+        other => {
+            if let Some(segment) = path_ahead.first() {
+                return Err(expected_collection_error(&other, segment));
+            }
+            patch_scalar(other, path_behind, path_ahead, before, remove, add, after, strategy)
+        }
+    }
+}
+
+fn patch_scalar(
+    node: Node,
+    path_behind: Vec<PathSegment>,
+    path_ahead: &[PathSegment],
+    _before: &[Node],
+    old_values: &[Node],
+    new_values: &[Node],
+    _after: &[Node],
+    strategy: PatchStrategy,
+) -> Result<Node, PatchError> {
+    if !path_ahead.is_empty() {
+        if let Some(segment) = path_ahead.first() {
+            return Err(expected_collection_error(&node, segment));
+        }
+    }
+    if old_values.len() > 1 || new_values.len() > 1 {
+        return Err(non_set_diff_error(old_values, new_values, &path_behind));
+    }
+    let old_value = single_value(old_values);
+    let new_value = single_value(new_values);
+    match strategy {
+        PatchStrategy::Merge => {
+            if !is_void(&old_value) {
+                return Err(PatchError::new(format!(
+                    "patch with merge strategy at {} has unnecessary old value {}",
+                    path_to_string(&path_behind),
+                    node_json(&old_value)
+                )));
+            }
+        }
+        PatchStrategy::Strict => {
+            if !node_equals(&node, &old_value) {
+                return Err(expect_value_error(&old_value, &node, &path_behind));
+            }
+        }
+    }
+    Ok(new_value)
+}
+
+fn patch_object(
+    mut map: BTreeMap<String, Node>,
+    path_behind: Vec<PathSegment>,
+    path_ahead: &[PathSegment],
+    _before: &[Node],
+    old_values: &[Node],
+    new_values: &[Node],
+    _after: &[Node],
+    strategy: PatchStrategy,
+) -> Result<Node, PatchError> {
+    if path_ahead.is_empty() {
+        if old_values.len() > 1 || new_values.len() > 1 {
+            return Err(non_set_diff_error(old_values, new_values, &path_behind));
+        }
+        let new_value = single_value(new_values);
+        if strategy == PatchStrategy::Merge {
+            return Ok(new_value);
+        }
+        let old_value = single_value(old_values);
+        if !node_equals(&Node::Object(map.clone()), &old_value) {
+            return Err(expect_value_error(&old_value, &Node::Object(map), &path_behind));
+        }
+        return Ok(new_value);
+    }
+
+    let (segment, rest) = path_ahead.split_first().unwrap();
+    let PathSegment::Key(key) = segment else {
+        return Err(PatchError::new(format!(
+            "found {} at {}: expected JSON object",
+            node_json(&Node::Object(map.clone())),
+            path_to_string(&path_behind)
+        )));
+    };
+
+    let mut next = map.get(key).cloned();
+    if next.is_none() {
+        next = Some(match strategy {
+            PatchStrategy::Merge => {
+                if rest.is_empty() {
+                    Node::Void
+                } else {
+                    Node::Object(BTreeMap::new())
+                }
+            }
+            PatchStrategy::Strict => Node::Void,
+        });
+    }
+
+    let mut new_path = path_behind.clone();
+    new_path.push(PathSegment::Key(key.clone()));
+    let patched =
+        patch_element(next.unwrap(), new_path, rest, &[], old_values, new_values, &[], strategy)?;
+
+    if is_void(&patched) {
+        map.remove(key);
+    } else {
+        map.insert(key.clone(), patched);
+    }
+    Ok(Node::Object(map))
+}
+
+fn patch_list(
+    list: Vec<Node>,
+    path_behind: Vec<PathSegment>,
+    path_ahead: &[PathSegment],
+    before: &[Node],
+    remove: &[Node],
+    add: &[Node],
+    after: &[Node],
+    strategy: PatchStrategy,
+) -> Result<Node, PatchError> {
+    if strategy == PatchStrategy::Merge {
+        return patch_scalar(
+            Node::Array(list),
+            path_behind,
+            path_ahead,
+            before,
+            remove,
+            add,
+            after,
+            strategy,
+        );
+    }
+
+    if path_ahead.is_empty() {
+        if remove.len() > 1 || add.len() > 1 {
+            return Err(PatchError::new("cannot replace list with multiple values"));
+        }
+        if remove.is_empty() {
+            return Err(PatchError::new("invalid diff. must declare list to replace it"));
+        }
+        let wanted = &remove[0];
+        let current = Node::Array(list);
+        if !node_equals(&current, wanted) {
+            return Err(PatchError::new(format!(
+                "wanted {}. found {}",
+                node_json(wanted),
+                node_json(&current)
+            )));
+        }
+        if add.is_empty() {
+            return Ok(Node::Void);
+        }
+        return Ok(add[0].clone());
+    }
+
+    let (segment, rest) = path_ahead.split_first().unwrap();
+    let PathSegment::Index(raw_index) = segment else {
+        return Err(invalid_path_element_error(segment));
+    };
+
+    if !rest.is_empty() {
+        if *raw_index < 0 || (*raw_index as usize) >= list.len() {
+            return Err(PatchError::new(format!("patch index out of bounds: {}", raw_index)));
+        }
+        let mut new_path = path_behind.clone();
+        new_path.push(PathSegment::Index(*raw_index));
+        let mut list_clone = list.clone();
+        let child = list_clone[*raw_index as usize].clone();
+        let patched = patch_element(child, new_path, rest, &[], remove, add, &[], strategy)?;
+        list_clone[*raw_index as usize] = patched;
+        return Ok(Node::Array(list_clone));
+    }
+
+    if *raw_index == -1 {
+        if !remove.is_empty() {
+            return Err(PatchError::new(
+                "invalid patch. appending to -1 index. but want to remove values",
+            ));
+        }
+        let mut list_clone = list.clone();
+        list_clone.extend(add.iter().cloned());
+        return Ok(Node::Array(list_clone));
+    }
+
+    if *raw_index < 0 {
+        return Err(PatchError::new(format!("patch index out of bounds: {}", raw_index)));
+    }
+
+    let insertion_index = *raw_index as usize;
+    let original = list.clone();
+
+    for (offset, context) in before.iter().enumerate() {
+        let distance = before.len() - offset;
+        let check_index = (*raw_index as isize) - (distance as isize);
+        if check_index < 0 {
+            if check_index == -1 && is_void(context) {
+                continue;
+            }
+            return Err(PatchError::new(format!(
+                "invalid patch. before context {} out of bounds: {}",
+                node_json(context),
+                check_index
+            )));
+        }
+        let check_index = check_index as usize;
+        if !node_equals(&original[check_index], context) {
+            return Err(PatchError::new(format!(
+                "invalid patch. expected {} before. got {}",
+                node_json(context),
+                node_json(&original[check_index])
+            )));
+        }
+    }
+
+    let mut working = original.clone();
+    if !remove.is_empty() {
+        if insertion_index >= working.len() {
+            return Err(PatchError::new(format!("remove values out bounds: {}", raw_index)));
+        }
+        for expected in remove {
+            if !node_equals(&working[insertion_index], expected) {
+                return Err(PatchError::new(format!(
+                    "invalid patch. wanted {}. found {}",
+                    node_json(expected),
+                    node_json(&working[insertion_index])
+                )));
+            }
+            working.remove(insertion_index);
+        }
+    }
+
+    if insertion_index > working.len() {
+        return Err(PatchError::new(format!("remove values out bounds: {}", raw_index)));
+    }
+
+    let mut result = Vec::with_capacity(working.len() + add.len());
+    result.extend(working.iter().take(insertion_index).cloned());
+    result.extend(add.iter().cloned());
+    result.extend(working.iter().skip(insertion_index).cloned());
+
+    for (offset, context) in after.iter().enumerate() {
+        let check_index = insertion_index + offset;
+        if check_index >= working.len() {
+            if check_index == working.len() && is_void(context) {
+                continue;
+            }
+            return Err(PatchError::new(format!(
+                "invalid patch. after context {} out of bounds: {}",
+                node_json(context),
+                check_index
+            )));
+        }
+        if !node_equals(&working[check_index], context) {
+            return Err(PatchError::new(format!(
+                "invalid patch. expected {} after. got {}",
+                node_json(context),
+                node_json(&working[check_index])
+            )));
+        }
+    }
+
+    Ok(Node::Array(result))
+}
+
+fn non_set_diff_error(
+    old_values: &[Node],
+    new_values: &[Node],
+    path: &[PathSegment],
+) -> PatchError {
+    if old_values.len() > 1 {
+        PatchError::new(format!(
+            "invalid diff: multiple removals from non-set at {}",
+            path_to_string(path)
+        ))
+    } else if new_values.len() > 1 {
+        PatchError::new(format!(
+            "invalid diff: multiple additions to a non-set at {}",
+            path_to_string(path)
+        ))
+    } else {
+        PatchError::new(format!(
+            "invalid diff: multiple additions to a non-set at {}",
+            path_to_string(path)
+        ))
+    }
+}
+
+fn expect_value_error(expected: &Node, found: &Node, path: &[PathSegment]) -> PatchError {
+    PatchError::new(format!(
+        "found {} at {}: expected {}",
+        node_json(found),
+        path_to_string(path),
+        node_json(expected)
+    ))
+}
+
+fn expected_collection_error(node: &Node, segment: &PathSegment) -> PatchError {
+    let expected = match segment {
+        PathSegment::Key(_) => "JSON object",
+        PathSegment::Index(_) => "JSON array",
+    };
+    PatchError::new(format!("found {} at {}: expected {}", node_json(node), segment, expected))
+}
+
+fn invalid_path_element_error(segment: &PathSegment) -> PatchError {
+    let type_name = match segment {
+        PathSegment::Key(_) => "string",
+        PathSegment::Index(_) => "float64",
+    };
+    PatchError::new(format!("invalid path element {}: expected float64", type_name))
+}
+
+fn single_value(values: &[Node]) -> Node {
+    values.first().cloned().unwrap_or(Node::Void)
+}
+
+fn is_void(node: &Node) -> bool {
+    matches!(node, Node::Void)
+}
+
+fn node_equals(lhs: &Node, rhs: &Node) -> bool {
+    lhs == rhs
+}
+
+fn node_json(node: &Node) -> String {
+    match node {
+        Node::Void => String::new(),
+        Node::Number(number) => {
+            let value = number.get();
+            if value.fract() == 0.0 {
+                format!("{:.0}", value)
+            } else {
+                serde_json::Number::from_f64(value)
+                    .map(|n| n.to_string())
+                    .unwrap_or_else(String::new)
+            }
+        }
+        _ => match node.to_json_value() {
+            Some(value) => serde_json::to_string(&value).unwrap_or_default(),
+            None => String::new(),
+        },
+    }
+}
+
+fn path_to_string(path: &[PathSegment]) -> String {
+    Path::from(path.to_vec()).to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn node_json_void() {
+        assert_eq!(node_json(&Node::Void), "");
+    }
+
+    #[test]
+    fn node_json_number_is_minimal() {
+        let node = Node::from_json_str("1").unwrap();
+        let rendered = node_json(&node);
+        assert_eq!(rendered, "1");
+
+        let json_number = serde_json::Number::from_f64(1.0).unwrap();
+        assert_eq!(json_number.to_string(), "1.0");
+    }
+}

--- a/crates/jd-core/tests/patch.rs
+++ b/crates/jd-core/tests/patch.rs
@@ -1,0 +1,76 @@
+use jd_core::{DiffOptions, Node};
+use proptest::prop_assert_eq;
+
+#[test]
+fn apply_patch_replaces_scalar() {
+    let base = Node::from_json_str("1").unwrap();
+    let target = Node::from_json_str("2").unwrap();
+    let diff = base.diff(&target, &DiffOptions::default());
+    let patched = base.apply_patch(&diff).unwrap();
+    assert_eq!(patched, target);
+}
+
+#[test]
+fn apply_patch_handles_object_insertion() {
+    let base = Node::from_json_str("{\"a\":1}").unwrap();
+    let target = Node::from_json_str("{\"a\":1,\"b\":2}").unwrap();
+    let diff = base.diff(&target, &DiffOptions::default());
+    let patched = base.apply_patch(&diff).unwrap();
+    assert_eq!(patched, target);
+}
+
+#[test]
+fn apply_patch_list_context_validation_errors() {
+    let base = Node::from_json_str("[1,2,3]").unwrap();
+    let target = Node::from_json_str("[1,4,3]").unwrap();
+    let diff = base.diff(&target, &DiffOptions::default());
+    let mismatched = Node::from_json_str("[0,2,3]").unwrap();
+    let err = mismatched.apply_patch(&diff).expect_err("patch should fail due to context mismatch");
+    assert_eq!(err.to_string(), "invalid patch. expected 1 before. got 0");
+}
+
+fn arb_json_value() -> impl proptest::strategy::Strategy<Value = serde_json::Value> {
+    use proptest::{collection::btree_map, collection::vec, prelude::*, string::string_regex};
+
+    let leaf = prop_oneof![
+        Just(serde_json::Value::Null),
+        any::<bool>().prop_map(serde_json::Value::Bool),
+        proptest::num::f64::ANY.prop_filter_map("finite", |f| {
+            if f.is_finite() {
+                serde_json::Number::from_f64(f).map(serde_json::Value::Number)
+            } else {
+                None
+            }
+        }),
+        string_regex("[a-zA-Z0-9]{0,6}").unwrap().prop_map(serde_json::Value::String),
+    ];
+
+    leaf.prop_recursive(3, 6, 4, move |inner| {
+        prop_oneof![
+            vec(inner.clone(), 0..4).prop_map(serde_json::Value::Array),
+            btree_map(string_regex("[a-zA-Z0-9]{1,6}").unwrap(), inner, 0..4).prop_map(|map| {
+                let mut object = serde_json::Map::new();
+                for (k, v) in map {
+                    object.insert(k, v);
+                }
+                serde_json::Value::Object(object)
+            }),
+        ]
+    })
+}
+
+proptest::proptest! {
+    #[test]
+    fn diff_and_patch_roundtrip(a_json in arb_json_value(), b_json in arb_json_value()) {
+        let a = Node::from_json_value(a_json.clone()).unwrap();
+        let b = Node::from_json_value(b_json.clone()).unwrap();
+        let opts = DiffOptions::default();
+        let diff = a.diff(&b, &opts);
+        let patched = a.apply_patch(&diff).unwrap();
+        prop_assert_eq!(patched, b.clone());
+
+        let reverse = b.diff(&a, &opts);
+        let restored = b.apply_patch(&reverse).unwrap();
+        prop_assert_eq!(restored, a);
+    }
+}

--- a/crates/jd-core/tests/render.proptest-regressions
+++ b/crates/jd-core/tests/render.proptest-regressions
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc c765ec47426ba485012b0140dc923c3a330e1cb3a50d3f62c8f44028c806ae8b # shrinks to a_json = Array [Bool(false), Null], b_json = Array [Null, Null]

--- a/crates/jd-core/tests/render.rs
+++ b/crates/jd-core/tests/render.rs
@@ -1,0 +1,160 @@
+use jd_core::{
+    diff::PathSegment, Diff, DiffElement, DiffMetadata, DiffOptions, Node, RenderConfig,
+};
+use proptest::prelude::*;
+
+fn simple_diff() -> Diff {
+    let lhs = Node::from_json_str("{\"a\":1}").unwrap();
+    let rhs = Node::from_json_str("{\"a\":2}").unwrap();
+    lhs.diff(&rhs, &DiffOptions::default())
+}
+
+#[test]
+fn render_native_object_replacement() {
+    let diff = simple_diff();
+    let rendered = diff.render(&RenderConfig::default());
+    assert_eq!(rendered, "@ [\"a\"]\n- 1\n+ 2\n");
+}
+
+#[test]
+fn render_native_string_diff_colorizes() {
+    let lhs = Node::from_json_str("\"kitten\"").unwrap();
+    let rhs = Node::from_json_str("\"sitting\"").unwrap();
+    let diff = lhs.diff(&rhs, &DiffOptions::default());
+    let rendered = diff.render(&RenderConfig::default().with_color(true));
+    assert!(rendered.contains("\u{1b}[31m"), "expected ANSI red segment");
+    assert!(rendered.contains("\u{1b}[32m"), "expected ANSI green segment");
+}
+
+#[test]
+fn render_patch_emits_context_tests() {
+    let lhs = Node::from_json_str("[1,2,3]").unwrap();
+    let rhs = Node::from_json_str("[1,4,3]").unwrap();
+    let diff = lhs.diff(&rhs, &DiffOptions::default());
+    let patch = diff.render_patch().expect("render_patch");
+    assert_eq!(
+        patch,
+        "[{\"op\":\"test\",\"path\":\"/0\",\"value\":1},{\"op\":\"test\",\"path\":\"/2\",\"value\":3},{\"op\":\"test\",\"path\":\"/1\",\"value\":2},{\"op\":\"remove\",\"path\":\"/1\",\"value\":2},{\"op\":\"add\",\"path\":\"/1\",\"value\":4}]"
+    );
+}
+
+#[test]
+fn render_patch_rejects_extra_context() {
+    let element = DiffElement::new()
+        .with_path(PathSegment::index(0))
+        .with_before(vec![Node::Null, Node::Null])
+        .with_remove(vec![Node::Null]);
+    let diff = Diff::from_elements(vec![element]);
+    let err = diff.render_patch().unwrap_err();
+    assert_eq!(err.to_string(), "only one line of before context supported. got 2");
+}
+
+#[test]
+fn render_patch_rejects_numeric_object_keys() {
+    let element = DiffElement::new()
+        .with_path(PathSegment::key("0"))
+        .with_remove(vec![Node::Null])
+        .with_add(vec![Node::Null]);
+    let diff = Diff::from_elements(vec![element]);
+    let err = diff.render_patch().unwrap_err();
+    assert!(err
+        .to_string()
+        .contains("JSON Pointer does not support object keys that look like numbers"));
+}
+
+#[test]
+fn render_merge_outputs_object() {
+    let element = DiffElement::new()
+        .with_metadata(DiffMetadata::merge())
+        .with_path(PathSegment::key("name"))
+        .with_add(vec![Node::from_json_str("\"jd\"").unwrap()]);
+    let diff = Diff::from_elements(vec![element]);
+    let rendered = diff.render_merge().expect("render_merge");
+    assert_eq!(rendered, "{\"name\":\"jd\"}");
+}
+
+#[test]
+fn render_merge_requires_merge_metadata() {
+    let element = DiffElement::new()
+        .with_path(PathSegment::key("name"))
+        .with_add(vec![Node::from_json_str("\"jd\"").unwrap()]);
+    let diff = Diff::from_elements(vec![element]);
+    let err = diff.render_merge().unwrap_err();
+    assert_eq!(err.to_string(), "cannot render non-merge element as merge");
+}
+
+#[test]
+fn render_raw_serializes_diff() {
+    let diff = simple_diff();
+    let raw = diff.render_raw().expect("render_raw");
+    let parsed: serde_json::Value = serde_json::from_str(&raw).expect("valid json");
+    assert!(parsed.is_array());
+    assert_eq!(parsed.as_array().unwrap().len(), 1);
+}
+
+#[test]
+fn reverse_swaps_add_remove() {
+    let diff = simple_diff();
+    let reversed = diff.reverse().expect("reverse");
+    let base = Node::from_json_str("{\"a\":2}").unwrap();
+    let patched = base.apply_patch(&reversed).expect("patch");
+    assert_eq!(patched, Node::from_json_str("{\"a\":1}").unwrap());
+}
+
+#[test]
+fn reverse_rejects_merge_diffs() {
+    let element = DiffElement::new()
+        .with_metadata(DiffMetadata::merge())
+        .with_path(PathSegment::key("a"))
+        .with_add(vec![Node::from_json_str("1").unwrap()]);
+    let diff = Diff::from_elements(vec![element]);
+    let err = diff.reverse().unwrap_err();
+    assert_eq!(err.to_string(), "cannot reverse merge diff element at [a]");
+}
+
+fn arb_json_value() -> impl Strategy<Value = serde_json::Value> {
+    use proptest::{collection, string::string_regex};
+
+    let leaf = prop_oneof![
+        Just(serde_json::Value::Null),
+        any::<bool>().prop_map(serde_json::Value::Bool),
+        proptest::num::f64::ANY.prop_filter_map("finite", |f| {
+            if f.is_finite() {
+                serde_json::Number::from_f64(f).map(serde_json::Value::Number)
+            } else {
+                None
+            }
+        }),
+        string_regex("[a-zA-Z0-9]{0,6}").unwrap().prop_map(serde_json::Value::String),
+    ];
+
+    leaf.prop_recursive(3, 6, 4, |inner| {
+        prop_oneof![
+            collection::vec(inner.clone(), 0..4).prop_map(serde_json::Value::Array),
+            collection::btree_map(string_regex("[a-zA-Z0-9]{1,6}").unwrap(), inner, 0..4).prop_map(
+                |map| {
+                    let mut object = serde_json::Map::new();
+                    for (k, v) in map {
+                        object.insert(k, v);
+                    }
+                    serde_json::Value::Object(object)
+                }
+            ),
+        ]
+    })
+}
+
+proptest! {
+    #[test]
+    fn reverse_round_trip_property(a_json in arb_json_value(), b_json in arb_json_value()) {
+        let a = Node::from_json_value(a_json.clone()).unwrap();
+        let b = Node::from_json_value(b_json.clone()).unwrap();
+        let opts = DiffOptions::default();
+        let diff = a.diff(&b, &opts);
+        let reversed = diff.reverse().unwrap();
+        let forward = a.apply_patch(&diff).unwrap();
+        prop_assert_eq!(forward, b.clone());
+        let backward = b.apply_patch(&reversed).unwrap();
+        prop_assert_eq!(backward, a);
+    }
+}

--- a/docs/specs/patch-renderers.md
+++ b/docs/specs/patch-renderers.md
@@ -1,0 +1,52 @@
+# Patch Rendering & Reverse Operations Specification
+
+## Scope
+- Extend `jd-core` with rendering support for the native jd diff format, RFC 6902 JSON Patch, RFC 7386 JSON Merge Patch, and a raw JSON debug view.
+- Provide an explicit `Diff::reverse` helper mirroring Go patch semantics for strict-mode diffs so higher layers can validate round-trips.
+- Expose ergonomic render configuration describing color output without exposing internal metadata toggles.
+
+## Goals
+- Match Go `jd` v2.2.2 output byte-for-byte for all supported renderings.
+- Preserve metadata inheritance semantics when rendering or reversing diffs.
+- Surface descriptive errors for unsupported transformations (e.g., reversing a merge diff, rendering invalid list contexts into JSON Patch).
+- Keep APIs fully documented with runnable doctests and minimal allocations.
+
+## Non-Goals
+- Implement set/multiset aware renderers (deferred to milestones covering set semantics).
+- Recreate the Go option-style variadic API; we expose a strongly typed Rust configuration instead.
+- Provide streaming readers for patch/merge inputs; parsing will ship alongside CLI integration.
+
+## API Surface
+- `pub struct RenderConfig { pub color: bool }` with `Default` (color disabled) and builder-style helpers.
+- `pub enum RenderError` with variants for unsupported merges, invalid contexts, pointer failures, and serialization issues.
+- `impl Diff` additions:
+  - `pub fn render(&self, config: &RenderConfig) -> String` – native jd text (supports color when `config.color`).
+  - `pub fn render_patch(&self) -> Result<String, RenderError>` – strict-mode JSON Patch.
+  - `pub fn render_merge(&self) -> Result<String, RenderError>` – merge patch serialization via patch engine (requires merge metadata).
+  - `pub fn render_raw(&self) -> Result<String, RenderError>` – `serde_json` dump of the diff structure for debugging.
+  - `pub fn reverse(&self) -> Result<Diff, RenderError>` – swap additions/removals for strict diffs while validating metadata inheritance.
+- `impl DiffElement` helper `fn render_native(&self, config: &RenderConfig, inherited: &DiffMetadata) -> String` (module-private).
+- `impl DiffMetadata { pub fn render_header(&self) -> String }` mirroring Go metadata lines.
+- `impl Path { pub fn to_node(&self) -> Node; pub fn to_pointer(&self) -> Result<String, RenderError> }` with JSON pointer escaping rules.
+
+## Design Notes
+- Native renderer replicates Go's line-based format, including `[` / `]` sentinels for void context and colorized single-string diffs by computing a character-level LCS.
+- JSON Patch renderer enforces the same restrictions as Go (single line of before/after context, prohibiting "numeric-looking" object keys) and generates `test/remove/add` sequences.
+- Merge renderer first validates that every element (including inherited metadata) is merge-enabled, coerces `Void` additions to `Null`, then patches against `Node::Void` to reuse the canonicalization pipeline.
+- `reverse` walks elements while tracking inherited metadata. Encountering merge metadata yields an error because original values are not preserved in merge diffs.
+- Raw renderer serializes via `serde_json::to_string` to ease golden generation in future milestones.
+
+## Testing Strategy
+- Unit tests comparing native render output for representative diffs (object change, list substitution, string diff with colors disabled/enabled).
+- JSON Patch golden-style assertions for array substitution verifying context tests, and failure cases (multiple before context, empty add/remove) returning specific errors.
+- Merge renderer success case using a manually constructed merge diff and failure when encountering strict hunks.
+- Property test exercising `reverse`: for random JSON pairs under list semantics, ensure `apply_patch(diff.reverse(), target) == base`.
+- Doctests for each public API demonstrating usage and expected strings.
+
+## Risks & Mitigations
+- **Pointer escaping**: implement dedicated helper mirroring Go's logic (reject numeric-looking keys, escape `~` and `/`). Add unit tests for edge cases.
+- **Color diff accuracy**: reuse deterministic LCS routine for rune sequences; add targeted test covering unicode input.
+- **Merge reversibility**: document in rustdoc and errors that merge diffs cannot be reversed; guard via metadata traversal.
+
+## Dependencies
+- No new external crates required; rely on `serde_json` for serialization and internal helpers.


### PR DESCRIPTION
## Summary
- add a jd-core `patch` module that applies diffs with strict/merge semantics and parity-friendly error messages
- expose `Node::apply_patch` and display helpers for paths, and wire dedicated patch property/smoke tests
- document the milestone 5 recon findings that guided the patch implementation

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68d52feafb3c833198eb8bbe537ae37b