### PR TITLE
Document CLI recon for milestone 7 and clarify color parity

### DIFF
--- a/ADRs/0003-clarify-color-handling.md
+++ b/ADRs/0003-clarify-color-handling.md
@@ -1,0 +1,22 @@
+# 0003 — Clarify CLI Color Handling Parity
+
+## Status
+Accepted
+
+## Context
+The implementation plan for Milestone 7 calls for supporting `-color`, `-nocolor`, and the `NO_COLOR` environment variable as part of the CLI parity work.【e9580e†L89-L93】 The upstream Go CLI (v2.2.2), however, only exposes a `-color` boolean flag; it neither defines a `-nocolor` counterpart nor inspects `NO_COLOR` or TTY state before rendering diffs.【a69894†L18-L111】【765c3b†L229-L283】 Enabling extra toggles in the Rust port would diverge from the parity guardrail.
+
+## Decision
+Implement the Rust CLI to match Go behavior exactly: only honor an explicit `-color` flag to request ANSI styling, defaulting to plain output otherwise. Defer any additional toggles (`-nocolor`, `NO_COLOR`, auto TTY detection) unless upstream introduces them or a future ADR authorizes parity-breaking UX changes.
+
+## Alternatives Considered
+- **Add `-nocolor`/`NO_COLOR` support anyway:** Rejected because it would add new behaviors not present upstream, violating parity and increasing maintenance burden for undocumented options.
+- **Auto-detect terminal capabilities:** Rejected for the same parity reasons; Go always emits plain text unless `-color` is explicitly set.
+
+## Consequences
+- Tests and documentation will describe color behavior exactly as upstream, simplifying cross-implementation parity checks.
+- Future enhancements to color handling require explicit ADRs referencing upstream changes or a conscious divergence decision.
+
+## References
+- Implementation plan CLI task list.【e9580e†L89-L96】
+- Go CLI flag definitions and render option wiring.【a69894†L18-L111】【765c3b†L229-L283】

--- a/docs/status.md
+++ b/docs/status.md
@@ -104,3 +104,21 @@
 ### Next Steps
 - Expand renderer coverage with larger fixtures and cross-implementation parity snapshots, especially for set/multiset semantics slated for later milestones.
 - Begin wiring CLI render mode flags (`-n`, `-p`, `-m`, etc.) to the new renderer APIs while preserving merge/set metadata behavior for future work.
+
+## Status — Milestone 7 (CLI Parity & UX Recon)
+
+### Summary
+- Re-verified the Go CLI flag definitions, usage banner, and mutually exclusive mode handling so the Rust CLI can mirror them exactly.
+- Confirmed argument arity rules for diff, patch, translate, and git diff driver modes, including stdout/stderr/exit-code semantics for each path.
+- Documented that colorized output is only enabled when `-color` is passed; there is no upstream `-nocolor` flag or `NO_COLOR` environment override.
+
+### Findings & References
+1. **Flag surface & version handling** – The CLI exposes the `-color`, `-f`, `-git-diff-driver`, `-mset`, `-o`, `-p`, `-port`, `-precision`, `-set`, `-setkeys`, `-t`, `-version`, `-yaml`, and deprecated `-v2` flags; `-version` prints `jd version 2.2.2` and exits. Mode selection rejects simultaneous `-p` and `-t`. [(v2.2.2/v2/jd/main.go#L18-L111)](https://github.com/josephburnett/jd/blob/v2.2.2/v2/jd/main.go#L18-L111)
+2. **Usage banner & exit codes** – `printUsageAndExit` emits the documented multi-line banner (including blank lines and examples) before exiting with status 2. [(v2.2.2/v2/jd/main.go#L157-L199)](https://github.com/josephburnett/jd/blob/v2.2.2/v2/jd/main.go#L157-L199)
+3. **Argument arity & IO routing** – Diff/patch modes accept one or two positional arguments (second input defaults to STDIN), translate accepts zero or one, and git diff driver requires seven arguments; diff exits 1 when changes are detected, otherwise 0, while patch/translate always exit 0 on success. [(v2.2.2/v2/jd/main.go#L72-L379)](https://github.com/josephburnett/jd/blob/v2.2.2/v2/jd/main.go#L72-L379)
+4. **Color behavior** – The renderer only adds `jd.COLOR` when `-color` is supplied; there is no automatic TTY detection or `NO_COLOR` handling in upstream. [(v2.2.2/v2/jd/main.go#L229-L283)](https://github.com/josephburnett/jd/blob/v2.2.2/v2/jd/main.go#L229-L283)
+
+### Next Steps
+- Mirror these flag definitions and mutually exclusive combinations in the Clap-based parser.
+- Add argument arity validation tests and snapshots that assert exit codes and help/usage text match upstream.
+- Reflect the absence of auto color toggles when reconciling the implementation plan for Milestone 7.


### PR DESCRIPTION
## Summary
- record milestone 7 CLI parity reconnaissance results with upstream references
- capture an ADR clarifying that only the -color flag should affect ANSI output, matching Go jd

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d5526ae91483318647a922d1134969