### PR TITLE
Add code vs documentation sync report

### DIFF
--- a/docs/code-doc-sync-report.md
+++ b/docs/code-doc-sync-report.md
@@ -1,0 +1,18 @@
+# Code vs Documentation Synchronization Report
+
+## Summary
+- Reviewed the architecture notes, final report, status artifacts, release notes, benchmarks, and implementation plan under `docs/`.
+- Compared the documented feature claims against the current Rust workspace, focusing on the CLI (`crates/jd-cli`), test suite layout, and supporting crates.
+- Identified several documentation statements that no longer match the implemented functionality and recorded recommended follow-ups.
+
+## Detailed Findings
+| Documentation | Stated Behavior | Observed Implementation | Impact |
+| --- | --- | --- | --- |
+| Release notes draft asserts full parity with Go `jd`, including patch and translate modes, and parity across merge/set configurations.【F:docs/release-notes/v0.1.0.md†L3-L10】 | The CLI still returns explicit `not implemented` errors for patch/translate execution and set/mset/setkeys metadata flags.【F:crates/jd-cli/src/main.rs†L136-L167】 | Users following the release notes will expect working patch/translate/set parity and be surprised by immediate failures. |
+| Final report overview states the workspace "mirrors the Go `jd` CLI" alongside diff, patch, renderers, fuzzing, and benchmarks.【F:docs/final-report.md†L3-L14】 | Only diff mode is wired into the CLI; patch/translate remain stubs while other components (fuzzing, benches) are present.【F:crates/jd-cli/src/main.rs†L136-L148】 | Stakeholders reading the final report will assume CLI parity is complete even though milestone work remains outstanding. |
+| Architecture doc describes `tests/` as housing CLI integration tests with Go-generated golden fixtures.【F:docs/architecture.md†L7-L12】【F:docs/architecture.md†L41-L46】 | The only entry under `tests/` is a README example smoke test; no CLI integration or golden fixtures are present.【F:tests/readme_examples.rs†L1-L14】 | Contributors relying on the architecture notes will look for non-existent fixtures/tests, slowing onboarding and parity validation. |
+
+## Recommendations
+1. Treat the final report and release notes as a feature contract and finish wiring up patch/translate/set support in the CLI so the published claims become accurate.
+2. Build out the documented CLI integration tests and golden fixtures under `tests/` to satisfy the architecture commitments rather than scaling the docs back.
+3. As new functionality lands, validate that the docs still match the shipped behavior as part of the delivery checklist so regressions are caught immediately.


### PR DESCRIPTION
## Summary
- add a synchronization report under `docs/` capturing discrepancies between the documentation set and the current codebase
- update the report recommendations to focus on implementing the promised functionality so docs stay accurate without being scaled back

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d58a17537083319ef797e0453a3852